### PR TITLE
refactor(conversations): move the reattach family out of the server

### DIFF
--- a/apps/fountain/lib/fountain/conversations/conversation_server.ex
+++ b/apps/fountain/lib/fountain/conversations/conversation_server.ex
@@ -1164,7 +1164,7 @@ defmodule Fountain.Conversations.ConversationServer do
               sandbox_started_at: Lifecycle.clock_start(sandbox)
           }
 
-          new_state = reattach_running_turn(%{new_state | current_turn: nil})
+          new_state = Reattachment.reattach_running_turn(%{new_state | current_turn: nil})
 
           new_state =
             Reattachment.finish_runner_reconnect(
@@ -1227,7 +1227,7 @@ defmodule Fountain.Conversations.ConversationServer do
             "transient; sandbox row left untouched"
         )
 
-        running_turn = find_running_turn(state.conversation_id)
+        running_turn = Reattachment.find_running_turn(state.conversation_id)
 
         if sandbox.provider == "runner" and
              reason in [
@@ -1245,169 +1245,6 @@ defmodule Fountain.Conversations.ConversationServer do
           {:stop, :normal, state}
         end
     end
-  end
-
-  # If a turn is marked `running` in the DB and the sprite has an active
-  # detachable session, reattach to it: the WebSocket reconnects, stdout
-  # continues streaming where it left off, and the eventual `:exit` message
-  # closes the turn cleanly. If no active session is found, the command
-  # finished while the BEAM was down — we don't know the exit code, so
-  # mark the orphaned turn `interrupted` so the user gets a clear signal.
-  defp reattach_running_turn(state) do
-    running_turn = find_running_turn(state.conversation_id)
-
-    if is_nil(running_turn) do
-      # No turn was in flight, but a deploy also killed the idle peer that
-      # outlives a turn (#817), leaving its detachable adapter session running
-      # with nothing to drive it. Reap it — by this conversation's tag, never
-      # the head of the list: a co-tenant's live turn on the same machine must
-      # not be touched (ADR 0023, #1058).
-      reap_orphan_sessions(state)
-    else
-      case Managoat.Sandbox.Retry.with_backoff(
-             fn -> Managoat.Sandbox.list_sessions(state.handle) end,
-             label: "session list on reattach"
-           ) do
-        {:ok, sessions} ->
-          # Don't filter by `is_active`: a detached session reports
-          # `is_active: false` while no client is connected, but the
-          # underlying exec is alive and `attach_session` resumes its
-          # stream (replaying the session buffer + live-tailing).
-          #
-          # Match on the conversation tag, never the head of the list: with
-          # several conversations on one machine, the head is as likely to be
-          # someone else's process as ours (`Fountain.Conversations.Identity`).
-          case Fountain.Conversations.Identity.reattach_session(
-                 state.handle,
-                 sessions,
-                 state.conversation_id
-               ) do
-            :none ->
-              mark_orphan(state, running_turn, "no_active_session")
-              state
-
-            {:ok, session, matched_by} ->
-              attempt_session_attach(state, running_turn, session, matched_by)
-          end
-
-        {:error, reason} ->
-          Logger.warning("list_sessions failed during reattach: #{inspect(reason)}")
-          mark_orphan(state, running_turn, "list_sessions_failed")
-          state
-      end
-    end
-  end
-
-  # After a restart with no turn in flight, stop this conversation's own
-  # leftover adapter sessions (#817). Matched by tag; a session tagged for
-  # another conversation, or untagged, is left alone.
-  defp reap_orphan_sessions(state) do
-    case Managoat.Sandbox.list_sessions(state.handle) do
-      {:ok, sessions} ->
-        mine =
-          Fountain.Conversations.Identity.owned_sessions(
-            state.handle,
-            sessions,
-            state.conversation_id
-          )
-
-        Enum.each(mine, &Connection.reap_session(state.handle, &1.id))
-
-        outcome = if mine == [], do: "no_running_turn", else: "orphan_session_reaped"
-
-        Output.publish_stage(state.conversation_id, "reattach", "done", %{
-          outcome: outcome,
-          reaped: length(mine)
-        })
-
-        state
-
-      {:error, _reason} ->
-        Output.publish_stage(state.conversation_id, "reattach", "done", %{
-          outcome: "no_running_turn"
-        })
-
-        state
-    end
-  end
-
-  defp attempt_session_attach(state, running_turn, session, matched_by) do
-    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
-    acp? = Fountain.RuntimeDispatch.acp_enabled?(conv.runtime)
-
-    case Managoat.Sandbox.attach(state.handle, session.id, owner: self(), stdin: true) do
-      {:ok, idle_command} when acp? and is_nil(running_turn.acp_prompt_id) ->
-        # The previous peer died before it wrote `session/prompt` (or the turn
-        # predates the column). The adapter is sitting idle in its handshake
-        # with nothing to answer, and no peer can pick that up: the ids it
-        # would need are gone with the process. Stop it — otherwise it lingers
-        # as a session the next reattach could bind to — and orphan the turn.
-        Managoat.Sandbox.stop_command(idle_command)
-        mark_orphan(state, running_turn, "acp_prompt_not_sent")
-        state
-
-      {:ok, command} ->
-        # sprites replays the tail of the session's buffered output before
-        # live-tailing. On the legacy path, count the bytes we already
-        # persisted for this turn so the stdout/stderr handlers can drop the
-        # replayed prefix. On the ACP path the peer re-encodes protocol lines
-        # so byte counts do not line up; the replayed lines are matched by
-        # content instead (`replay_dedup`).
-        replay_skip =
-          if acp?,
-            do: %{},
-            else:
-              Conversations._unsafe_output_bytes_by_stream(
-                state.conversation_id,
-                running_turn.id
-              )
-
-        Output.publish_stage(state.conversation_id, "reattach", "done", %{
-          outcome: "session_attached",
-          matched_by: matched_by,
-          session_id: session.id,
-          turn_id: running_turn.id,
-          turn_number: running_turn.turn_number,
-          replay_skip_bytes: replay_skip,
-          acp_prompt_id: running_turn.acp_prompt_id
-        })
-
-        {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
-
-        # turn_metrics stays nil on purpose, so this turn contributes no
-        # duration sample (#536). Its start is in a previous BEAM lifetime:
-        # monotonic time isn't comparable across a restart, and measuring
-        # from the row's started_at would fold the whole deploy gap into the
-        # histogram. A missing sample beats a wrong one.
-        state = %{
-          state
-          | current_command: command,
-            current_command_ref: command.ref,
-            current_turn: running_turn,
-            replay_skip: replay_skip
-        }
-
-        if acp?, do: Reattachment.acp_peer(state, running_turn, conv), else: state
-
-      {:error, reason} ->
-        Logger.warning("attach_session failed: #{inspect(reason)}")
-        mark_orphan(state, running_turn, "attach_failed")
-        state
-    end
-  end
-
-  defp mark_orphan(_state, running_turn, why),
-    do: Conversations._unsafe_orphan_turn(running_turn, why)
-
-  defp find_running_turn(conv_id) do
-    import Ecto.Query
-
-    Fountain.Repo.one(
-      from t in Fountain.Conversations.Turn,
-        where: t.conversation_id == ^conv_id and t.status == "running",
-        order_by: [desc: t.turn_number],
-        limit: 1
-    )
   end
 
   # ── sprite environment and egress (ADR 0019 gate 1a) ──────────────────────

--- a/apps/fountain/lib/fountain/conversations/reattachment.ex
+++ b/apps/fountain/lib/fountain/conversations/reattachment.ex
@@ -186,4 +186,172 @@ defmodule Fountain.Conversations.Reattachment do
         runner_replay: nil
     }
   end
+
+  # If a turn is marked `running` in the DB and the sprite has an active
+  # detachable session, reattach to it: the WebSocket reconnects, stdout
+  # continues streaming where it left off, and the eventual `:exit` message
+  # closes the turn cleanly. If no active session is found, the command
+  # finished while the BEAM was down — we don't know the exit code, so
+  # mark the orphaned turn `interrupted` so the user gets a clear signal.
+  def reattach_running_turn(state) do
+    running_turn = find_running_turn(state.conversation_id)
+
+    if is_nil(running_turn) do
+      # No turn was in flight, but a deploy also killed the idle peer that
+      # outlives a turn (#817), leaving its detachable adapter session running
+      # with nothing to drive it. Reap it — by this conversation's tag, never
+      # the head of the list: a co-tenant's live turn on the same machine must
+      # not be touched (ADR 0023, #1058).
+      reap_orphan_sessions(state)
+    else
+      case Managoat.Sandbox.Retry.with_backoff(
+             fn -> Managoat.Sandbox.list_sessions(state.handle) end,
+             label: "session list on reattach"
+           ) do
+        {:ok, sessions} ->
+          # Don't filter by `is_active`: a detached session reports
+          # `is_active: false` while no client is connected, but the
+          # underlying exec is alive and `attach_session` resumes its
+          # stream (replaying the session buffer + live-tailing).
+          #
+          # Match on the conversation tag, never the head of the list: with
+          # several conversations on one machine, the head is as likely to be
+          # someone else's process as ours (`Fountain.Conversations.Identity`).
+          case Fountain.Conversations.Identity.reattach_session(
+                 state.handle,
+                 sessions,
+                 state.conversation_id
+               ) do
+            :none ->
+              mark_orphan(state, running_turn, "no_active_session")
+              state
+
+            {:ok, session, matched_by} ->
+              attempt_session_attach(state, running_turn, session, matched_by)
+          end
+
+        {:error, reason} ->
+          Logger.warning("list_sessions failed during reattach: #{inspect(reason)}")
+          mark_orphan(state, running_turn, "list_sessions_failed")
+          state
+      end
+    end
+  end
+
+  # After a restart with no turn in flight, stop this conversation's own
+  # leftover adapter sessions (#817). Matched by tag; a session tagged for
+  # another conversation, or untagged, is left alone.
+  defp reap_orphan_sessions(state) do
+    case Managoat.Sandbox.list_sessions(state.handle) do
+      {:ok, sessions} ->
+        mine =
+          Fountain.Conversations.Identity.owned_sessions(
+            state.handle,
+            sessions,
+            state.conversation_id
+          )
+
+        Enum.each(mine, &Connection.reap_session(state.handle, &1.id))
+
+        outcome = if mine == [], do: "no_running_turn", else: "orphan_session_reaped"
+
+        Output.publish_stage(state.conversation_id, "reattach", "done", %{
+          outcome: outcome,
+          reaped: length(mine)
+        })
+
+        state
+
+      {:error, _reason} ->
+        Output.publish_stage(state.conversation_id, "reattach", "done", %{
+          outcome: "no_running_turn"
+        })
+
+        state
+    end
+  end
+
+  defp attempt_session_attach(state, running_turn, session, matched_by) do
+    # ownership: the server's bound conversation and the running turn
+    # `find_running_turn/1` read for it; no id here came from a request.
+    conv = Conversations._unsafe_get_conversation!(state.conversation_id)
+    acp? = Fountain.RuntimeDispatch.acp_enabled?(conv.runtime)
+
+    case Managoat.Sandbox.attach(state.handle, session.id, owner: self(), stdin: true) do
+      {:ok, idle_command} when acp? and is_nil(running_turn.acp_prompt_id) ->
+        # The previous peer died before it wrote `session/prompt` (or the turn
+        # predates the column). The adapter is sitting idle in its handshake
+        # with nothing to answer, and no peer can pick that up: the ids it
+        # would need are gone with the process. Stop it — otherwise it lingers
+        # as a session the next reattach could bind to — and orphan the turn.
+        Managoat.Sandbox.stop_command(idle_command)
+        mark_orphan(state, running_turn, "acp_prompt_not_sent")
+        state
+
+      {:ok, command} ->
+        # sprites replays the tail of the session's buffered output before
+        # live-tailing. On the legacy path, count the bytes we already
+        # persisted for this turn so the stdout/stderr handlers can drop the
+        # replayed prefix. On the ACP path the peer re-encodes protocol lines
+        # so byte counts do not line up; the replayed lines are matched by
+        # content instead (`replay_dedup`).
+        # ownership: as above — the bound conversation and its own running turn.
+        replay_skip =
+          if acp?,
+            do: %{},
+            else:
+              Conversations._unsafe_output_bytes_by_stream(
+                state.conversation_id,
+                running_turn.id
+              )
+
+        Output.publish_stage(state.conversation_id, "reattach", "done", %{
+          outcome: "session_attached",
+          matched_by: matched_by,
+          session_id: session.id,
+          turn_id: running_turn.id,
+          turn_number: running_turn.turn_number,
+          replay_skip_bytes: replay_skip,
+          acp_prompt_id: running_turn.acp_prompt_id
+        })
+
+        {:ok, _} = Conversations.update_conversation(conv, %{status: "running"})
+
+        # turn_metrics stays nil on purpose, so this turn contributes no
+        # duration sample (#536). Its start is in a previous BEAM lifetime:
+        # monotonic time isn't comparable across a restart, and measuring
+        # from the row's started_at would fold the whole deploy gap into the
+        # histogram. A missing sample beats a wrong one.
+        state = %{
+          state
+          | current_command: command,
+            current_command_ref: command.ref,
+            current_turn: running_turn,
+            replay_skip: replay_skip
+        }
+
+        if acp?, do: acp_peer(state, running_turn, conv), else: state
+
+      {:error, reason} ->
+        Logger.warning("attach_session failed: #{inspect(reason)}")
+        mark_orphan(state, running_turn, "attach_failed")
+        state
+    end
+  end
+
+  # ownership: `running_turn` came from `find_running_turn/1`, scoped to the
+  # conversation this server owns.
+  defp mark_orphan(_state, running_turn, why),
+    do: Conversations._unsafe_orphan_turn(running_turn, why)
+
+  def find_running_turn(conv_id) do
+    import Ecto.Query
+
+    Fountain.Repo.one(
+      from t in Fountain.Conversations.Turn,
+        where: t.conversation_id == ^conv_id and t.status == "running",
+        order_by: [desc: t.turn_number],
+        limit: 1
+    )
+  end
 end

--- a/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_size_test.exs
@@ -30,14 +30,23 @@ defmodule Fountain.Conversations.ConversationServerSizeTest do
   only fails at the moment the last one lands.
   """
 
-  # 2646 → 2641. `start_provision_watchdog/2` moved out to
-  # `Fountain.Conversations.ProvisionWatchdog`, taking 81 lines with it and
-  # putting the file at 2565. The pin is not lowered to 2565: the number has
-  # not stopped moving. The #1766/#1767 campaign is measured at +68 across
-  # its 26 open PRs, landing the file at 2633, and the remaining 8 lines are
-  # for the two of them still in review rounds. Tighten this to the file's
-  # real length in a follow-up once that campaign has landed.
-  @pin 2641
+  # 2641 → 2549. The reattachment family — `reattach_running_turn/1`,
+  # `reap_orphan_sessions/1`, `attempt_session_attach/4`, `mark_orphan/3` and
+  # `find_running_turn/1` — moved to `Fountain.Conversations.Reattachment`,
+  # which already owned the ACP half of the same path. That takes 163 lines
+  # out and puts the file at 2466.
+  #
+  # The pin is not lowered to 2466: the #1766/#1767 campaign is still in
+  # flight below it. Measured today across its 18 open PRs, by diffing each
+  # chain tip against the base it forks from rather than summing per-PR
+  # counts, its remaining net is **+73** to this file — #1975 +10, the
+  # #1978→#2007 chain +58, #1977 +5, #1979 +0 — landing the file at 2539.
+  # (#2037 measured +68 a day ago; two review rounds on #1981 and #1982 have
+  # moved it since, which is exactly the drift this moduledoc warns about.)
+  #
+  # 2549 is that 2539 plus 10 lines for the rounds still to come. Tighten it
+  # to the file's real length in a follow-up once the campaign has landed.
+  @pin 2549
 
   @server "apps/fountain/lib/fountain/conversations/conversation_server.ex"
 


### PR DESCRIPTION
The reattachment family — `reattach_running_turn/1`, `reap_orphan_sessions/1`, `attempt_session_attach/4`, `mark_orphan/3` and `find_running_turn/1` — becomes `Fountain.Conversations.Reattachment`, the #1369 subtraction pattern, following #2037.

`Reattachment` is already where the other half of this path lives: `acp_peer/3` is what `attempt_session_attach/4` calls on its ACP arm, and `wait_for_runner/2`, `fail_transport/2` and `disconnect_runner/1` are the same recovery concern. The move puts the whole path in one module and takes **163 lines** out of `conversation_server.ex`, from 2629 to **2466**.

## The move is verbatim

The bodies are byte-identical to the originals apart from three edits, diffed whitespace-normalized:

| line | before | after |
|---|---|---|
| `reattach_running_turn/1` | `defp` | `def` — the server still calls it |
| `find_running_turn/1` | `defp` | `def` — the server calls it on the transient-reattach-failure arm too |
| ACP arm of `attempt_session_attach/4` | `Reattachment.acp_peer(...)` | `acp_peer(...)` — now a local call |

Nothing else, and no behaviour change. `reap_orphan_sessions/1`, `attempt_session_attach/4` and `mark_orphan/3` stay private.

The state coupling needed no adapter. `Reattachment`'s local convention is to take and return the server's `state` map whole (`acp_peer/3`, `wait_for_runner/2`, `disconnect_runner/1` all do), and it reaches for `Pending.from_state`/`into_state` only where it touches that sub-struct. The moved functions do the same, so they moved as they were rather than being reshaped.

`self()` still names the server: every one of these is a plain call from the server process, so `Managoat.Sandbox.attach(..., owner: self(), ...)`, `Process.send_after/3` and `Process.monitor/1` all bind exactly as before.

## The pin goes to 2549, not 2466

`main` was at `@pin 2641`. The `#1766`/`#1767` campaign is still in flight below it, so the pin is not lowered to the file's new length — the moduledoc's own guidance (#1565).

I measured the campaign's remaining net myself rather than reusing #2037's figure, by diffing each **chain tip** against the base it forks from. Summing per-PR `additions - deletions` overcounts a stack, and #1973 is now merged:

| chain | net to `conversation_server.ex` |
|---|---|
| #1975 (`lifecycle-fence`, off `main`) | +10 |
| #1978 → #1980 → #1981 → #1982 → #1983 → #1996 → #1998 → #1999 → #2000 → #2001 → #2002 → #2003 → #2006 → #2007 | +58 |
| #1977 (via #1976) | +5 |
| #1979 (`termination-attach-order`) | 0 |
| **remaining total** | **+73** |

That lands the file at **2539**. `@pin 2549` is that plus 10 lines for the review rounds still to come.

**#2037 measured +68 a day ago; it is +73 today** — two more rounds on #1981 and #1982 moved it, which is exactly the drift the moduledoc warns about. A pin of 2513 (2466 + the older +47 estimate) would have gone red the moment the campaign landed. 2549 is still 92 below the current pin, so the ratchet moves down hard; tighten it to the real length in a follow-up once the campaign has landed.

## Conflict surface

The move is at lines 1249-1411 of the old file. The campaign's remaining PRs edit roughly 1543-1600 and 2038-2130, far outside it, and none of them touches the pin line — so `main`'s lowering wins silently, as it did for #2037.

## Verification

- `mix compile --warnings-as-errors` clean.
- `mix format --check-formatted` clean.
- `mix credo --strict` from the umbrella root: 862 files, **no issues**. The three `_unsafe_` reads (`_unsafe_get_conversation!`, `_unsafe_output_bytes_by_stream`, `_unsafe_orphan_turn`) carry inline `# ownership:` comments rather than a new entry in `.credo.exs`'s `exempt_paths`, as in #2037 — `Reattachment` is not a GenServer or a system sweep, and it reads exactly the conversation the server is bound to and the running turn it looked up for that conversation. `reattachment.ex` was already off the exempt list and already justified its existing `_unsafe_` calls this way.
- **The full `apps/fountain` suite: 6 doctests, 5731 tests, 0 failures, 2 skipped**, against a dedicated database (the shared `fountain_test` is contaminated — it carries an `inference_credentials.name NOT NULL` column that no migration on `main` creates).
- The size test passes at 2466 against the new pin.

Refs #1369, #2032, #1767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReRhgGKTWxrNuAUAe22C3L
