### PR TITLE
test(conversations): wait for the probe to appear in the registry

### DIFF
--- a/apps/fountain/test/fountain/conversations/termination_client_test.exs
+++ b/apps/fountain/test/fountain/conversations/termination_client_test.exs
@@ -125,8 +125,27 @@ defmodule Fountain.Conversations.TerminationClientTest do
 
   defp probe(conv_id, reply) do
     pid = start_supervised!({Probe, {self(), reply, conv_id}})
-    assert ConversationServer.whereis(conv_id) == pid
+    await_registered(conv_id, pid)
     pid
+  end
+
+  # `Probe.init/1` registers in the cluster-wide Horde registry, and a CRDT
+  # registry does not guarantee the write is visible to `lookup/2` the instant
+  # `start_supervised!/1` returns. Asserting on the first read makes every test
+  # in this file a coin flip on registry propagation, which is how partition 6
+  # went red on an unrelated PR. Wait for the thing being asserted.
+  defp await_registered(conv_id, pid, remaining \\ 200) do
+    cond do
+      ConversationServer.whereis(conv_id) == pid ->
+        :ok
+
+      remaining == 0 ->
+        flunk("probe #{inspect(pid)} never became visible in the registry for #{conv_id}")
+
+      true ->
+        Process.sleep(10)
+        await_registered(conv_id, pid, remaining - 1)
+    end
   end
 
   defp events(ctx), do: Audit.list_for_user(ctx.user.id, action_prefix: "conversation.terminated")


### PR DESCRIPTION
`probe/2` in `termination_client_test.exs` asserted `ConversationServer.whereis(conv_id) == pid` on the **first** read after `start_supervised!/1`. `Probe.init/1` registers in `Fountain.ConversationRegistry` — Horde's CRDT-backed registry — and that write is not guaranteed visible to `lookup/2` the instant init returns. Every test in the file was a coin flip on registry propagation.

It surfaced on **#1982's** partition 6, a PR that touches none of this code:

```
1) test rolling deploy forwards only attribution keys to the actor
   Assertion with == failed
   left:  nil
   right: #PID<0.3654.0>
   test/fountain/conversations/termination_client_test.exs:112
```

The fix waits for the condition being asserted, bounded, with a `flunk` naming what never happened — rather than reading once and hoping.

Three consecutive green local runs (8 tests each); the same file failed in CI on the first read, which is the asymmetry you expect from a propagation race rather than a logic error.

These tests arrived with #1981 earlier today, so this is same-day cleanup of my own change, not an inherited flake.

Refs #1767, #1981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReRhgGKTWxrNuAUAe22C3L