### PR TITLE
test(runner): wait for CONNECT before rejecting guest socket (#1641)

### DIFF
--- a/cli/internal/runner/guestlink_test.go
+++ b/cli/internal/runner/guestlink_test.go
@@ -227,8 +227,13 @@ func TestDialGuestRejectsASocketThatDoesNotSpeakVsock(t *testing.T) {
 		if err != nil {
 			return
 		}
+		defer func() { _ = conn.Close() }()
+		// Consume CONNECT before replying so the close cannot race the
+		// client's write and hide the malformed-reply diagnostic.
+		if _, err := bufio.NewReader(conn).ReadString('\n'); err != nil {
+			return
+		}
 		_, _ = conn.Write([]byte("NO\n"))
-		_ = conn.Close()
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
Fixes #1641.

The malformed guest-socket fixture could close before `dialGuest` wrote its CONNECT request, producing a broken-pipe error instead of the intended guest-agent diagnostic. Read the request before sending `NO` and closing the socket. The existing assertion still requires an error naming `runner-guest`.

Validation (macOS ARM64, Go 1.26.5):
- 1,000 focused repetitions of `TestDialGuestRejectsASocketThatDoesNotSpeakVsock` passed.
- `cd cli && go test -count=1 ./...` and `go vet ./...` passed.
- `gofmt` and `git diff --check` passed.
- Full `mix precommit` passed on this exact commit in an isolated checkout with Elixir 1.19.2 / OTP 28.3 and a disposable test database: core 5,828 tests plus six doctests, zero failures (two skipped, seven excluded); Buzz 144 and Support 33 tests, zero failures. Compilation, formatting, Credo, Dialyzer, Sobelow and production-release assembly passed.

The initial sandboxed test attempt could not bind its temporary Unix socket; the tests above ran with socket access enabled.
