### PR TITLE
chore: clean stale library configuration and repository guidance (#1717)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ erl_crash.dump
 # Temporary files, for example, from tests.
 /tmp
 
+# Local Git worktrees.
+/.worktrees/
+
 # ExUnit's `@tag :tmp_dir` writes under the app that runs the test, not the
 # umbrella root, and the behavioural CA install test uses one.
 apps/*/tmp/

--- a/apps/fountain/mix.exs
+++ b/apps/fountain/mix.exs
@@ -50,8 +50,8 @@ defmodule Fountain.MixProject do
       # Apache-2.0, carries no reference back into Fountain, started life as an
       # app in this umbrella and has graduated to a managoat/managoat_<name>
       # repository that publishes to hex from its own CI. The pins are
-      # patch-level (~> 0.1.0) while everything is 0.x: a library's 0.2.0
-      # reaches Fountain only when someone bumps the pin here, on purpose.
+      # patch-level within each library's current minor release while everything
+      # is 0.x: a new minor reaches Fountain only when someone bumps its pin here.
       # A future library starts as {:managoat_<name>, in_umbrella: true}
       # again; umbrella_layout_test.exs checks it is listed here.
       {:managoat_acp, "~> 0.4.2"},

--- a/config/test.exs
+++ b/config/test.exs
@@ -151,7 +151,6 @@ config :fountain, :connections_req_options, plug: {Req.Test, Fountain.Connection
 config :fountain, :platform_chatgpt_req_options, plug: {Req.Test, Fountain.PlatformChatGPT.OAuth}
 # Discovery and the OAuth client refuse private hosts; the Req.Test stub
 # answers for any host, so the resolution check is off here (#1186).
-config :fountain, :connections_allow_private_hosts, true
 config :managoat_mcp_auth, :req_options, plug: {Req.Test, Fountain.Connections.OAuth}
 config :managoat_mcp_auth, :allow_private_hosts, true
 config :fountain, :gmail_req_options, plug: {Req.Test, Fountain.Connections.Gmail}

--- a/decisions/0037-component-libraries.md
+++ b/decisions/0037-component-libraries.md
@@ -40,9 +40,11 @@ checks the subject and audits; `Fountain.OAuth` is the instance and
 `managoat_broker` (#1340: the native egress credential proxy from PR #1148,
 ported rather than rebased; `CONNECT` and absolute-form forward proxy, the
 derived CA, the header injector, behind a `Managoat.Broker.Store` behaviour
-that `fountain` implements over the `broker_sessions` table; `fountain` runs
-it beside the Agent Vault client, selected by `BROKER_LISTEN_PORT`, until
-the deployment flips) and `managoat_acp` (#1339: the client-side ACP
+that `fountain` implements over the `broker_sessions` table; it is the only
+backend since the 2026-09-03 deployment flip and Agent Vault client removal
+(#1487), enabled by `BROKER_LISTEN_PORT`; see the amendment in
+[0019](0019-egress-credential-brokerage.md#amendment-2026-09-03-production-flipped-and-the-vendor-client-is-gone))
+and `managoat_acp` (#1339: the client-side ACP
 session that outlives the turn, the JSON-RPC framing, the permission policy,
 the block normaliser, usage accounting, the tracer and a `ScriptedAgent`,
 behind a writer callback rather than a sandbox dependency; runtime


### PR DESCRIPTION
Refs #1717 (partial cleanup).

Local worktrees appear as untracked files, the library dependency comment assumes every package is still at 0.1, and ADR 0037 still describes the retired Agent Vault coexistence period. Ignore `/.worktrees/`, describe the existing per-library minor pins accurately, and align the ADR status paragraph with the native-only broker already recorded in ADR 0019. Remove the unused `:fountain, :connections_allow_private_hosts` test setting; preserve the live `:managoat_mcp_auth, :allow_private_hosts` setting.

Validation:
- `git check-ignore -v .worktrees/example/README.md` and `git diff --check` pass.
- Evaluated old/new test configuration with `Config.Reader`: the only value removed is the unused Fountain key; the live library key remains `true`.
- `okf validate decisions` passes (0 errors; 6 existing actor-convention warnings in other ADRs). Ran `okf backlinks decisions 0037-component-libraries` before editing and regenerated the decisions index; it is unchanged.
- `/tmp/fountain-qw-env mix precommit apps/fountain/test/fountain/docs_test.exs apps/fountain/test/fountain/connections_test.exs apps/fountain/test/fountain/umbrella_layout_test.exs` passes on `43d23465bb7b7786353d7acd54d97cbffaf36fb8`: all compile, unused-dependency, format, Credo, Sobelow, Dialyzer and release-assembly stages completed; the scoped suite reports 46 tests, 0 failures. The wrapper selects Elixir 1.19.2 / OTP 28.3 and the isolated test database. This is scoped verification, not a full-suite run on this head.

This does not close #1717. The Hermes validation-error bullet is addressed separately in #2070. Its remaining bullets need separate assessment: broker private-upstream configuration documentation, Swift `onboarding_state`, checkpoint event registration, recovery audit evidence, the #1626/#1624 issue-reference mismatch, and optional library patch-release consumption. No dependency versions or runtime broker policy change here.

The ADR edit corrects an implementation-status fact; it does not change the recorded architecture. `decisions/**` is covered by the existing Review Loop human-review policy.
