### PR TITLE
fix(oauth): explain loopback origins accept any port (#1897)

### DIFF
--- a/apps/fountain/lib/fountain_web/live/oauth_clients_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/oauth_clients_live/index.ex
@@ -122,7 +122,7 @@ defmodule FountainWeb.OAuthClientsLive.Index do
     origins = Enum.join(Client.origins_of(redirect_uris), ", ")
 
     if Enum.any?(redirect_uris, &loopback_uri?/1),
-      do: origins <> " (and a loopback origin on any port)",
+      do: origins <> " (loopback: any port)",
       else: origins
   end
 

--- a/apps/fountain/test/fountain_web/live/oauth_clients_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/oauth_clients_live_test.exs
@@ -36,7 +36,7 @@ defmodule FountainWeb.OAuthClientsLiveTest do
     assert html =~ "In development"
     # A loopback redirect was registered, so the card must not imply that
     # :5173 is the only origin CORS will admit.
-    assert html =~ "any port"
+    assert html =~ "(loopback: any port)"
   end
 
   test "shows the validation error rather than saving", %{conn: conn} do

--- a/cli/internal/cmd/oauthclient.go
+++ b/cli/internal/cmd/oauthclient.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/managoat/fountain/cli/api"
@@ -166,5 +167,26 @@ func printOAuthClient(a oauthClient) {
 	fmt.Printf("name:          %s\n", a.Name)
 	fmt.Printf("mode:          %s\n", mode(a))
 	fmt.Printf("redirect_uris: %s\n", strings.Join(a.RedirectURIs, "\n               "))
-	fmt.Printf("origins:       %s\n", strings.Join(a.Origins, ", "))
+	origins := strings.Join(a.Origins, ", ")
+	for _, uri := range a.RedirectURIs {
+		if oauthClientLoopbackURI(uri) {
+			origins += " (loopback: any port)"
+			break
+		}
+	}
+	fmt.Printf("origins:       %s\n", origins)
+}
+
+// Mirrors Fountain.OAuth.Client.loopback?/1 in apps/fountain/lib/fountain/oauth/client.ex.
+func oauthClientLoopbackURI(uri string) bool {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(u.Hostname()) {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
 }

--- a/cli/internal/cmd/oauthclient_test.go
+++ b/cli/internal/cmd/oauthclient_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPrintOAuthClientOrigins(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		uris     []string
+		origins  []string
+		loopback bool
+	}{
+		{"localhost", []string{"http://localhost:5173/callback"}, []string{"http://localhost:5173"}, true},
+		{"uppercase localhost", []string{"https://LOCALHOST/callback"}, []string{"https://localhost"}, true},
+		{"IPv4", []string{"http://127.0.0.1:8080/callback"}, []string{"http://127.0.0.1:8080"}, true},
+		{"IPv6", []string{"http://[::1]:8080/callback"}, []string{"http://[::1]:8080"}, true},
+		{"IPv6 without port", []string{"http://[::1]/callback"}, []string{"http://[::1]"}, true},
+		{"mixed origins", []string{"https://notes.test/callback", "http://localhost:5173/callback", "http://127.0.0.1:8080/callback"}, []string{"https://notes.test", "http://localhost:5173", "http://127.0.0.1:8080"}, true},
+		{"remote", []string{"https://notes.test/callback"}, []string{"https://notes.test"}, false},
+		{"localhost subdomain", []string{"https://localhost.notes.test/callback"}, []string{"https://localhost.notes.test"}, false},
+		{"loopback in path", []string{"https://notes.test/localhost"}, []string{"https://notes.test"}, false},
+		{"other IPv4 loopback", []string{"https://127.0.0.2/callback"}, []string{"https://127.0.0.2"}, false},
+		{"malformed", []string{"http://[::1"}, nil, false},
+		{"relative", []string{"localhost/callback"}, nil, false},
+		{"empty", nil, nil, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, err := os.CreateTemp(t.TempDir(), "stdout")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { stdout.Close() })
+			original := os.Stdout
+			os.Stdout = stdout
+			t.Cleanup(func() { os.Stdout = original })
+
+			printOAuthClient(oauthClient{RedirectURIs: tt.uris, Origins: tt.origins})
+
+			got, err := os.ReadFile(stdout.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := "origins:       " + strings.Join(tt.origins, ", ")
+			if tt.loopback {
+				want += " (loopback: any port)"
+			}
+			lines := strings.Split(strings.TrimSuffix(string(got), "\n"), "\n")
+			if last := lines[len(lines)-1]; last != want {
+				t.Errorf("origins line = %q, want %q", last, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
OAuth apps registered with a loopback redirect previously showed only the registered port in CLI output, even though CORS accepts that origin on any port. The shared create/update printer now appends `(loopback: any port)` for `localhost`, `127.0.0.1`, and `::1`; console cards use the same wording.

The JSON response and origin authorization are unchanged. The current CLI list command only shows redirect URIs and has no origin field; no `get` command exists.

Fixes #1897.

Validation:

- `go test -count=1 ./...` and `go vet ./...` in `cli/` passed with Go 1.26.5.
- The printer regression covers all three hosts, uppercase localhost, IPv6 with and without a port, mixed origins, non-loopback hosts, malformed and relative URIs, and an empty list.
- `mix precommit apps/fountain/test/fountain_web/live/oauth_clients_live_test.exs` passed under Elixir 1.19.2 / OTP 28.3: compile, unused-dependency checks, formatting, strict Credo, Sobelow, dev Dialyzer, production release assembly, and 5 focused tests with 0 failures. The full Elixir test suite was not rerun on this branch.
- Independent source review found no issues with host detection, JSON compatibility, or serial stdout capture in the tests.
