### PR TITLE
test(conversations): pass nil for absent permission params (#1901)

### DIFF
--- a/apps/fountain/test/fountain/conversations/pending_test.exs
+++ b/apps/fountain/test/fountain/conversations/pending_test.exs
@@ -97,7 +97,7 @@ defmodule Fountain.Conversations.PendingTest do
       turn: turn,
       pending: pending
     } do
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes", "no"], 60_000)
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes", "no"], nil)
 
       assert %{"request_id" => 7, "tool" => "bash", "options" => ["yes", "no"], "asked_at" => _} =
                turn.pending_permission
@@ -117,7 +117,7 @@ defmodule Fountain.Conversations.PendingTest do
       conv: conv,
       pending: pending
     } do
-      {nil, pending} = Pending.ask(pending, conv.id, nil, 7, "bash", [], 60_000)
+      {nil, pending} = Pending.ask(pending, conv.id, nil, 7, "bash", [], nil)
       assert [{"started", _}] = stages(conv.id, "request")
       Process.cancel_timer(pending.permission_timer)
     end
@@ -133,7 +133,7 @@ defmodule Fountain.Conversations.PendingTest do
       turn: turn,
       pending: pending
     } do
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], 60_000)
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], nil)
       timer = pending.permission_timer
       peer = fake_peer()
 
@@ -156,7 +156,7 @@ defmodule Fountain.Conversations.PendingTest do
       turn: turn,
       pending: pending
     } do
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], 60_000)
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], nil)
       peer = fake_peer()
 
       {turn, _pending} =
@@ -182,7 +182,7 @@ defmodule Fountain.Conversations.PendingTest do
       assert {nil, ^pending} =
                Pending.resolve_pending_permission(pending, conv.id, nil, nil, "turn_ended")
 
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 9, "rm", [], 60_000)
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 9, "rm", [], nil)
 
       {turn, pending} =
         Pending.resolve_pending_permission(pending, conv.id, turn, nil, "turn_ended")
@@ -212,7 +212,7 @@ defmodule Fountain.Conversations.PendingTest do
           end
         end)
 
-      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], 60_000)
+      {turn, pending} = Pending.ask(pending, conv.id, turn, 7, "bash", ["yes"], nil)
 
       assert {:ok, turn, pending} =
                Pending.answer_permission(pending, conv.id, turn, peer, 7, "yes")


### PR DESCRIPTION
Fixes #1901.

Six `Pending.ask/7` tests pass `60_000` as the request-params argument, although the function expects a params map or `nil`. Replace those values with `nil` to state that the tests use the policy/global timeout fallback. Existing permission and timer assertions remain intact.

Validation on this exact commit (Elixir 1.19.2 / OTP 28.3, disposable test database): `mix precommit apps/fountain/test/fountain/conversations/pending_test.exs` passed. Compilation, unused-dependency checks, formatting, Credo, Sobelow, Dialyzer and production-release assembly passed; the scoped Pending suite completed with 15 tests, zero failures. `git diff --check` also passed.
