### PR TITLE
docs: explain detached permission resume turn charges (#1902)

### DIFF
--- a/docs/concepts/permissions.md
+++ b/docs/concepts/permissions.md
@@ -109,6 +109,12 @@ so Fountain cannot hand the answer back down it. Instead Fountain resolves the
 request and opens a **new turn** whose prompt carries the outcome. Opening that
 turn wakes the sandbox.
 
+With `CREDITS_ENABLED=true`, this resume turn is billable on a platform-paid sandbox
+provider at the normal `CREDIT_TURN_HOUR_CENTS` rate. The expiry sweep opens the
+same billable turn when nobody answers before the deadline. The detached wait
+itself adds no turn time. Each later detached approval adds another resume
+turn. See [Prices](../guides/operate/plans-and-prices.md).
+
 The prompt is one line of JSON and nothing else. It is broken up here to read
 it.
 

--- a/docs/guides/operate/plans-and-prices.md
+++ b/docs/guides/operate/plans-and-prices.md
@@ -20,11 +20,18 @@ are no plans. Credits are the product.
 An unset price costs nothing. To turn one on is a price increase, and an
 explicit act.
 
-An hour of agent time is an hour with a prompt in flight. An agent that waits
-for a person spends nothing. Time on a self-hosted runner spends nothing,
+An hour of agent time is an hour with a prompt in flight on a platform-paid
+provider (Sprites, E2B or Daytona). Time on a self-hosted runner spends nothing,
 because Fountain pays nothing for that machine. Turn time adds up for each
 turn. Two conversations that each run for an hour on one sandbox spend two
 hours, on a sandbox that was busy for one.
+
+A [detached permission request](../../concepts/permissions.md#requests-that-outlive-a-turn)
+adds no turn time while it waits after its turn ends. An answer opens a new
+resume turn, and the expiry sweep opens the same turn when nobody answers.
+With billing enabled, Fountain prices each resume turn's duration at
+`CREDIT_TURN_HOUR_CENTS` per hour for platform-paid providers. A sequence of
+detached approvals therefore adds one resume turn per answer.
 
 ## The opening credit
 


### PR DESCRIPTION
Fixes #1902.

A detached permission answer starts a new turn, and automatic expiry starts the same turn with a timeout outcome. The manual described that restart without explaining its cost. Document both paths under “Answering one” and on the Prices page: the resume turn uses the normal duration-based rate for platform-paid providers when credits are enabled, the detached wait adds no turn time, and successive approvals add successive resume turns. Replace the Prices page's broad claim that any agent waiting for a person spends nothing with the precise detached-wait condition.

Validation:
- Traced answer and expiry through `Conversations.resume_after_request/5` into `ConversationServer.send_prompt/4`, and verified `CreditPricer` selects closed turns on `SandboxUsage.platform_paid_providers/0` and prices their duration.
- `git diff --check` passes; the two changed pages pass the docs-style checks and all 33 enabled Destink rules.
- The full docs-style report has the same three existing findings as the base. Vale has the same 28 existing error/warning findings as the base across these pages; this patch adds none. Prose reports remain advisory under repository policy.
- `/tmp/fountain-qw-env mix precommit apps/fountain/test/fountain/docs_test.exs apps/fountain/test/fountain_web/controllers/docs_controller_test.exs` passes on `27f5945fabf323622e769f6c8407bcfeadd4812b`: all compile, unused-dependency, format, Credo, Sobelow, Dialyzer and release-assembly stages completed; the scoped docs suite reports 43 tests, 0 failures. The wrapper selects Elixir 1.19.2 / OTP 28.3 and the isolated test database. This is scoped verification, not a full-suite run on this head.

Documentation only; no billing or permission behavior changes. The current Prices page is `docs/guides/operate/plans-and-prices.md`; the issue's former `docs/concepts/credits.md` path no longer exists.
