### PR TITLE
docs: explain diff confinement and root redaction (#1905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,7 +314,11 @@ upgrade, is in
 
 - Sandbox `/diff` returns 422 when Git fails after repository discovery,
   instead of reporting an empty diff. Intentional byte-cap truncation still
-  succeeds (#1904).
+  succeeds (#1904). It also returns `422 not_a_repository` when Git discovers
+  a repository above the sandbox's allowed roots, instead of returning that
+  repository's diff. This includes self-hosted runners inside a home directory
+  that is a dotfiles repository. The `repo_root` string now passes through
+  secret redaction; the response shape is unchanged (#1596, #1905).
 
 - **A reset refused by a bounded execution says so** (ADR 0046). Deleting a
   sandbox while a bounded turn still owed a remote stop answered `422` with an


### PR DESCRIPTION
Existing `/diff` callers can receive `422 not_a_repository` after Git discovers an ancestor repository outside the sandbox's allowed roots. Extend the current `/diff` release note with that behavior, the self-hosted runner dotfiles example, and secret redaction of `repo_root` with no response-shape change.

Fixes #1905.

Validation:

- Cross-checked the note against `SandboxFiles.diff/3`, the shared Git root confinement script, the 422 fallback mapping, and merged PR #1596.
- `git diff --check` and the repository's docs-style checks on the changed release-note paragraph passed.
- `mix precommit apps/fountain/test/fountain/docs_test.exs apps/fountain/test/fountain_web/controllers/docs_controller_test.exs` passed under Elixir 1.19.2 / OTP 28.3: compile, unused-dependency checks, formatting, strict Credo, Sobelow, dev Dialyzer, production release assembly, and 43 focused tests with 0 failures. The full Elixir test suite was not rerun on this branch.
