### PR TITLE
test(secrets): isolate global expiry notice configuration (#1932)

### DIFF
--- a/apps/fountain/test/fountain/async_global_config_guardrail_test.exs
+++ b/apps/fountain/test/fountain/async_global_config_guardrail_test.exs
@@ -54,8 +54,6 @@ defmodule Fountain.AsyncGlobalConfigGuardrailTest do
     "apps/fountain/test/fountain/webhooks_test.exs",
     # :retention_days — read only by the pruner under test.
     "apps/fountain/test/fountain/workers/retention_pruner_test.exs",
-    # :secret_expiry_notice_days — read only by the sweeper under test.
-    "apps/fountain/test/fountain/workers/secret_expiry_sweeper_test.exs",
     # :callback_key_ttl_seconds — read when a callback key is minted.
     "apps/fountain/test/fountain_web/api_key_scope_test.exs",
     # :buzz_cli_bin — read only by the buzz paths under test.

--- a/apps/fountain/test/fountain/workers/secret_expiry_sweeper_config_test.exs
+++ b/apps/fountain/test/fountain/workers/secret_expiry_sweeper_config_test.exs
@@ -1,0 +1,35 @@
+defmodule Fountain.Workers.SecretExpirySweeperConfigTest do
+  # The vault form also reads this global notice window. Run after async
+  # tests so disabling the sweep cannot change their expiry labels (#1932).
+  use Fountain.DataCase, async: false
+
+  import Swoosh.TestAssertions
+
+  alias Fountain.Workers.SecretExpirySweeper
+
+  test "notice_days 0 disables the sweep" do
+    previous = Application.fetch_env(:fountain, :secret_expiry_notice_days)
+
+    on_exit(fn ->
+      case previous do
+        {:ok, value} -> Application.put_env(:fountain, :secret_expiry_notice_days, value)
+        :error -> Application.delete_env(:fountain, :secret_expiry_notice_days)
+      end
+    end)
+
+    Application.put_env(:fountain, :secret_expiry_notice_days, 0)
+
+    user = insert_verified_user()
+    vault = insert_vault(user_id: user.id)
+
+    expires_at =
+      DateTime.utc_now()
+      |> DateTime.add(1, :day)
+      |> DateTime.truncate(:second)
+
+    insert_vault_secret(vault, key: "GH_TOKEN", expires_at: expires_at)
+
+    assert :ok = perform_job(SecretExpirySweeper, %{})
+    assert_no_email_sent()
+  end
+end

--- a/apps/fountain/test/fountain/workers/secret_expiry_sweeper_test.exs
+++ b/apps/fountain/test/fountain/workers/secret_expiry_sweeper_test.exs
@@ -111,17 +111,4 @@ defmodule Fountain.Workers.SecretExpirySweeperTest do
 
     assert_no_email_sent()
   end
-
-  test "notice_days 0 disables the sweep" do
-    user = insert_verified_user()
-    vault = insert_vault(user_id: user.id)
-    expiring(vault, "GH_TOKEN", 1)
-
-    Application.put_env(:fountain, :secret_expiry_notice_days, 0)
-    on_exit(fn -> Application.delete_env(:fountain, :secret_expiry_notice_days) end)
-
-    assert :ok = perform_job(SecretExpirySweeper, %{})
-
-    assert_no_email_sent()
-  end
 end


### PR DESCRIPTION
Fixes #1932.

The sweeper test temporarily sets the global secret-expiry notice window to zero. When it overlaps the vault-form tests, their three-day expiry label disappears. Move that configuration test into a synchronous sibling module and remove the stale guardrail allowlist entry. Restore the previous configuration after the test, including whether the key was absent.

The other sweeper tests remain asynchronous, and the sweep-disabled and vault-label assertions remain intact.

Validation on this exact commit (Elixir 1.19.2 / OTP 28.3, disposable test database):

```sh
mix precommit \
  apps/fountain/test/fountain/workers/secret_expiry_sweeper_test.exs \
  apps/fountain/test/fountain/workers/secret_expiry_sweeper_config_test.exs \
  apps/fountain/test/fountain_web/live/secret_forms_live_test.exs \
  apps/fountain/test/fountain/async_global_config_guardrail_test.exs
```

Passed compilation, unused-dependency checks, formatting, Credo, Sobelow, Dialyzer and production-release assembly. The combined scoped suite completed with 21 tests, zero failures. `git diff --check` also passed.
