### PR TITLE
fix(console): identify and confirm principal key replacement (#2030)

### DIFF
--- a/apps/fountain/lib/fountain/principals.ex
+++ b/apps/fountain/lib/fountain/principals.ex
@@ -145,6 +145,19 @@ defmodule Fountain.Principals do
     |> Repo.all()
   end
 
+  @doc "Owned principal IDs and their application names, oldest first."
+  @spec list_owned_details(binary()) :: [%{id: binary(), application_id: String.t() | nil}]
+  def list_owned_details(owner_user_id) when is_binary(owner_user_id) do
+    from(o in Owner,
+      left_join: c in ClaimableUser,
+      on: c.user_id == o.principal_user_id,
+      where: o.owner_user_id == ^owner_user_id,
+      order_by: [asc: o.inserted_at],
+      select: %{id: o.principal_user_id, application_id: c.application_id}
+    )
+    |> Repo.all()
+  end
+
   @doc """
   Whose ledger funds work done as `subject` (ADR 0044 decision 4).
 

--- a/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
+++ b/apps/fountain/lib/fountain_web/components/layouts/root.html.heex
@@ -242,6 +242,22 @@
 
         // ── LiveView hooks ───────────────────────────────────────────────────
         const Hooks = {
+          ConfirmSubmit: {
+            mounted() {
+              this.confirmSubmit = (event) => {
+                let confirmed = false;
+                try { confirmed = window.confirm(this.el.dataset.confirm); } catch (_) {}
+                if (!confirmed) {
+                  event.preventDefault();
+                  event.stopImmediatePropagation();
+                }
+              };
+              // Confirm a submission, not a click on a field inside the form.
+              // Cancellation stops the event before LiveView receives it.
+              this.el.addEventListener("submit", this.confirmSubmit, { capture: true });
+            },
+            destroyed() { this.el.removeEventListener("submit", this.confirmSubmit, { capture: true }); }
+          },
           // Prevents a collapsed <details> section from staying closed when
           // LiveView adds new content to it. Because `open?` is always `true`
           // for turn/recursive sections, LiveView's diff never re-sends the

--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -142,6 +142,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
         :if={@principals != []}
         id="renew-principal-key"
         phx-submit="renew_principal_key"
+        phx-hook="ConfirmSubmit"
         data-confirm="Replace this principal's key? Its current key will stop working."
         class="space-y-3 rounded border border-[var(--color-border)] p-4"
       >

--- a/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/api_keys_live/index.ex
@@ -15,7 +15,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
      |> assign(:page_title, "API keys")
      |> assign(:user_id, user.id)
      |> assign(:keys, keys)
-     |> assign(:principals, Principals.list_owned(user.id))
+     |> assign(:principals, Principals.list_owned_details(user.id))
      |> assign(:new_key, nil)}
   end
 
@@ -142,6 +142,7 @@ defmodule FountainWeb.ApiKeysLive.Index do
         :if={@principals != []}
         id="renew-principal-key"
         phx-submit="renew_principal_key"
+        data-confirm="Replace this principal's key? Its current key will stop working."
         class="space-y-3 rounded border border-[var(--color-border)] p-4"
       >
         <label for="principal-id" class="block font-medium">Replace a principal key</label>
@@ -154,7 +155,9 @@ defmodule FountainWeb.ApiKeysLive.Index do
           name="principal_id"
           class="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg-1)] p-2 text-sm"
         >
-          <option :for={id <- @principals} value={id}>{id}</option>
+          <option :for={principal <- @principals} value={principal.id}>
+            {principal_label(principal)}
+          </option>
         </select>
         <.button
           type="submit"
@@ -221,6 +224,12 @@ defmodule FountainWeb.ApiKeysLive.Index do
     </div>
     """
   end
+
+  defp principal_label(%{id: id, application_id: application_id})
+       when is_binary(application_id) and application_id != "",
+       do: "#{application_id} (#{id})"
+
+  defp principal_label(%{id: id}), do: id
 
   defp format_date(nil), do: ""
   defp format_date(dt), do: Calendar.strftime(dt, "%Y-%m-%d")

--- a/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
@@ -42,7 +42,7 @@ defmodule FountainWeb.ApiKeysLiveTest do
 
     assert has_element?(
              view,
-             ~s(#renew-principal-key[data-confirm="Replace this principal's key? Its current key will stop working."])
+             ~s(#renew-principal-key[phx-hook="ConfirmSubmit"][data-confirm="Replace this principal's key? Its current key will stop working."])
            )
 
     view

--- a/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/api_keys_live_test.exs
@@ -33,7 +33,17 @@ defmodule FountainWeb.ApiKeysLiveTest do
     {:ok, _, key} = Accounts.authenticate_api_key(claimed.api_key)
     {:ok, _} = Accounts.revoke_managed_api_key(owner.id, key.id)
     {:ok, view, _html} = conn |> login_user(owner) |> live(~p"/api-keys")
-    assert has_element?(view, "#renew-principal-key option[value='#{claimed.claimable.user_id}']")
+
+    assert has_element?(
+             view,
+             "#renew-principal-key option[value='#{claimed.claimable.user_id}']",
+             "renew-console (#{claimed.claimable.user_id})"
+           )
+
+    assert has_element?(
+             view,
+             ~s(#renew-principal-key[data-confirm="Replace this principal's key? Its current key will stop working."])
+           )
 
     view
     |> form("#renew-principal-key", principal_id: claimed.claimable.user_id)
@@ -73,6 +83,44 @@ defmodule FountainWeb.ApiKeysLiveTest do
     end
 
     assert {:ok, _, _} = Accounts.authenticate_api_key(claimed.api_key)
+  end
+
+  test "principal picker keeps unnamed owned principals and excludes another owner's names", %{
+    conn: conn
+  } do
+    owner = insert_verified_user()
+    other_owner = insert_verified_user()
+    app = insert_verified_user()
+    {:ok, principal} = Accounts.create_principal_user()
+
+    %Fountain.Principals.Owner{}
+    |> Fountain.Principals.Owner.changeset(%{
+      owner_user_id: owner.id,
+      principal_user_id: principal.id
+    })
+    |> Fountain.Repo.insert!()
+
+    {:ok, opened} =
+      Fountain.Principals.create_claimable(app, %{"application_id" => "another-owners-app"})
+
+    {:ok, claimed} =
+      Fountain.Principals.claim(opened.claimable.id, opened.claim_token, other_owner)
+
+    {:ok, view, html} = conn |> login_user(owner) |> live(~p"/api-keys")
+
+    label =
+      view
+      |> element("#renew-principal-key option[value='#{principal.id}']")
+      |> render()
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.text()
+      |> String.trim()
+
+    assert label == principal.id
+
+    refute has_element?(view, "#renew-principal-key option[value='#{claimed.claimable.user_id}']")
+    refute html =~ "another-owners-app"
+    assert Fountain.Principals.list_owned(owner.id) == [principal.id]
   end
 
   describe "ApiKeysLive.Index — rendering" do

--- a/deployed/test/principal-confirmation.test.mjs
+++ b/deployed/test/principal-confirmation.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+
+// Exercise the hook shipped in the console layout, not a test copy of it.
+const layout = readFileSync(new URL('../../apps/fountain/lib/fountain_web/components/layouts/root.html.heex', import.meta.url), 'utf8');
+const hooks = layout.match(/const Hooks = (\{[\s\S]*?\n        \});/);
+assert.ok(hooks, 'console layout must register its LiveView hooks');
+
+function mountConfirmation(answer) {
+  const prompts = [];
+  const { ConfirmSubmit } = runInNewContext(`(${hooks[1]})`, {
+    window: { confirm(message) {
+      prompts.push(message);
+      if (answer instanceof Error) throw answer;
+      return answer;
+    } }
+  });
+  const form = new EventTarget();
+  form.dataset = { confirm: "Replace this principal's key? Its current key will stop working." };
+  const hook = { el: form };
+  ConfirmSubmit.mounted.call(hook);
+  return { form, prompts, destroy: () => ConfirmSubmit.destroyed.call(hook) };
+}
+
+test('cancelling principal replacement stops submission before LiveView receives it', () => {
+  const { form, prompts } = mountConfirmation(false);
+  let submissions = 0;
+  form.addEventListener('submit', () => { submissions++; });
+  const event = new Event('submit', { cancelable: true });
+
+  assert.equal(form.dispatchEvent(event), false);
+  assert.equal(event.defaultPrevented, true);
+  assert.equal(submissions, 0);
+  assert.deepEqual(prompts, [form.dataset.confirm]);
+});
+
+test('accepting principal replacement permits the original submission exactly once', () => {
+  const { form, prompts } = mountConfirmation(true);
+  let submissions = 0;
+  form.addEventListener('submit', () => { submissions++; });
+
+  assert.equal(form.dispatchEvent(new Event('submit', { cancelable: true })), true);
+  assert.equal(submissions, 1);
+  assert.deepEqual(prompts, [form.dataset.confirm]);
+});
+
+test('a failed confirmation dialog leaves the current key unchanged', () => {
+  const { form } = mountConfirmation(new Error('dialog unavailable'));
+  let submissions = 0;
+  form.addEventListener('submit', () => { submissions++; });
+
+  assert.equal(form.dispatchEvent(new Event('submit', { cancelable: true })), false);
+  assert.equal(submissions, 0);
+});
+
+test('picker interactions do not prompt and destroying the hook removes its listener', () => {
+  const { form, prompts, destroy } = mountConfirmation(false);
+  for (const type of ['click', 'input', 'change']) form.dispatchEvent(new Event(type));
+  assert.deepEqual(prompts, []);
+
+  destroy();
+  assert.equal(form.dispatchEvent(new Event('submit', { cancelable: true })), true);
+  assert.deepEqual(prompts, []);
+});


### PR DESCRIPTION
The principal-key replacement form now asks for confirmation before replacing the current credential. Its picker shows each principal's application ID alongside its UUID, so owners can identify the key they intend to replace; principals without application metadata retain their UUID label.

A new owner-scoped display query preserves `Principals.list_owned/1`'s UUID return type for account deletion. Credential replacement eligibility is unchanged.

The console has no existing `data-confirm` handler, so a submit-only LiveView hook supplies the prompt. Cancelling or failing to open the dialog blocks submission; interacting with the picker does not prompt.

Fixes #2030.

Validation:

- Extended the existing LiveView renewal test to assert the application label and confirmation, retaining its credential replacement and revocation checks.
- Added a LiveView regression for the exact UUID fallback and exclusion of another owner's principal and application name.
- `node --test deployed/test/principal-confirmation.test.mjs` passed (4 tests). The shipped submit hook blocks cancellation and dialog errors, permits acceptance once, ignores picker events, and removes its listener on destruction.
- `node --test deployed/test/*.test.mjs` passed: 240 tests, 0 failures.
- A local headless Chrome page using the shipped hook passed cancel, accept, dialog-error, picker-click/change and listener-cleanup checks with a bubbling parent submit observer. This checks browser event behavior without a live server.
- `mix precommit apps/fountain/test/fountain_web/live/api_keys_live_test.exs apps/fountain/test/fountain/principals_test.exs` passed under Elixir 1.19.2 / OTP 28.3: compile, unused-dependency checks, formatting, strict Credo, Sobelow, dev Dialyzer, production release assembly, and 64 focused tests with 0 failures. The full Elixir suite was not rerun on this branch; the existing unrelated unused `conn` warning remains in the revoke test.
- `git diff --check` passed. Independent review verified owner scoping, preserved query compatibility, and the final confirmation hook.
