### PR TITLE
test(conversations): await cotenant registry visibility (#2053)

### DIFF
--- a/apps/fountain/test/fountain/conversations/lifecycle_actions_test.exs
+++ b/apps/fountain/test/fountain/conversations/lifecycle_actions_test.exs
@@ -14,6 +14,7 @@ defmodule Fountain.Conversations.LifecycleActionsTest do
   use Mimic
 
   alias Fountain.Conversations
+  alias Fountain.Conversations.ConversationServer
   alias Fountain.Conversations.Lifecycle
   alias Managoat.Sandbox.Handle
 
@@ -330,23 +331,26 @@ defmodule Fountain.Conversations.LifecycleActionsTest do
 
       # A plain process standing in for the co-tenant's server: `whereis/1`
       # only asks the registry, and a cast is a message.
-      {:ok, stand_in} =
-        Task.start_link(fn ->
-          {:ok, _} = Horde.Registry.register(Fountain.ConversationRegistry, other.id, nil)
-          send(test, :registered)
+      stand_in =
+        start_supervised!(
+          {Task,
+           fn ->
+             {:ok, _} = Horde.Registry.register(Fountain.ConversationRegistry, other.id, nil)
 
-          receive do
-            msg -> send(test, {:cotenant, msg})
-          end
-        end)
+             receive do
+               msg -> send(test, {:cotenant, msg})
+             end
+           end}
+        )
 
-      assert_receive :registered
+      # Registration can precede lookup visibility in Horde. Wait for the
+      # lookup that stop_cotenants/5 depends on, with a bounded deadline.
+      assert {:ok, ^stand_in} = ConversationServer.await_registered(other.id, 2_000)
 
       assert Lifecycle.stop_cotenants(ctx.sandbox.id, ctx.conv.id, "suspended", "idle", "why") ==
                :ok
 
       assert_receive {:cotenant, {:"$gen_cast", {:machine_gone, "suspended", "idle", "why"}}}
-      assert is_pid(stand_in)
     end
 
     test "a co-tenant with no live server is not an error", ctx do


### PR DESCRIPTION
Fixes #2053.

The cotenant test waited for a registration message before calling `stop_cotenants/5`, although Horde may not make that registration visible to lookup immediately. Use the existing bounded `ConversationServer.await_registered/2` helper and assert the exact stand-in PID is visible before exercising the cast. Run the stand-in under the test supervisor so a failed assertion also cleans it up.

The original `:machine_gone` cast assertion remains intact. Production cotenant behavior is unchanged.

Validation on this exact commit (Elixir 1.19.2 / OTP 28.3, disposable test database):

```sh
mix precommit \
  apps/fountain/test/fountain/conversations/lifecycle_actions_test.exs \
  apps/fountain/test/fountain/conversations/termination_client_test.exs
```

Passed compilation, unused-dependency checks, formatting, Credo, Sobelow, Dialyzer and production-release assembly. The scoped lifecycle and termination suites completed with 35 tests, zero failures. `git diff --check` also passed.
