### PR TITLE
fix(hermes): show field validation details (#1717)

### DIFF
--- a/integrations/hermes/fountain/client.py
+++ b/integrations/hermes/fountain/client.py
@@ -242,7 +242,7 @@ def _maybe_json(raw: bytes) -> Any:
 def _describe_http_error(status: int, parsed: Any, url: str) -> str:
     detail = ""
     if isinstance(parsed, dict):
-        err = parsed.get("error") or parsed.get("errors") or parsed.get("message")
+        err = parsed.get("errors") or parsed.get("error") or parsed.get("message")
         if err:
             detail = err if isinstance(err, str) else json.dumps(err)
     elif isinstance(parsed, str) and parsed.strip():

--- a/integrations/hermes/tests/test_plugin.py
+++ b/integrations/hermes/tests/test_plugin.py
@@ -5,11 +5,13 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import sys
 import tempfile
 import unittest
+import urllib.error
 from pathlib import Path
 from unittest import mock
 
@@ -107,6 +109,19 @@ class SettingsTests(unittest.TestCase):
 
 
 class ClientTests(unittest.TestCase):
+    def test_validation_errors_keep_field_details(self):
+        body = {"error": "validation_failed", "errors": {"prompt": ["can't be blank"]}}
+        response = urllib.error.HTTPError(
+            "https://fountain.test/api/conversations", 422, "rejected", {},
+            io.BytesIO(json.dumps(body).encode()),
+        )
+        with mock.patch("urllib.request.urlopen", side_effect=response):
+            with self.assertRaises(FountainError) as caught:
+                FountainClient("https://fountain.test", TOKEN).create_conversation("a-1", "")
+        self.assertEqual(caught.exception.status, 422)
+        self.assertEqual(caught.exception.body, body)
+        self.assertIn('"prompt": ["can\'t be blank"]', str(caught.exception))
+
     def test_agent_resolution(self):
         with FakeFountain() as fake:
             c = FountainClient(fake.base_url, TOKEN)


### PR DESCRIPTION
Refs #1717 (Hermes validation-error slice).

When Fountain returns `422` with both `error: validation_failed` and a field-level `errors` map, Hermes currently shows only the generic code. Prefer the field details so the caller sees which input was rejected. Responses without field errors retain the existing error/message fallback; status and the original parsed response body remain available on `FountainError`.

Validation:
- The new request-path regression fails before the fix because the prompt field message is missing.
- All 20 Hermes plugin tests pass after the fix.
- `git diff --check` passes.
- `/tmp/fountain-qw-env mix precommit` passes on `dab792361a894c704942e6bb9a2546376794695c`: compile, unused-dependency, format, Credo, Dialyzer, Sobelow and release-assembly checks completed; the full suite reports core 5,828 tests plus 6 doctests, Buzz 144 tests, and Support 33 tests, all with zero failures (core: 2 skipped, 7 excluded). The wrapper selects Elixir 1.19.2 / OTP 28.3 and an isolated test database.

This closes only the Hermes bullet. The repository cleanup is in #2060; its remaining SDK, runtime, audit and dependency bullets remain open.
