### PR TITLE
test(conversations): await timeout fixture registry visibility (#2005)

### DIFF
--- a/apps/fountain/test/fountain_web/controllers/conversation_call_timeout_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_call_timeout_test.exs
@@ -14,8 +14,15 @@ defmodule FountainWeb.ConversationCallTimeoutTest do
   # return value, not an exit.
 
   setup %{conn: conn} do
+    previous_timeout = Application.fetch_env(:fountain, :conversation_call_timeout_ms)
     Application.put_env(:fountain, :conversation_call_timeout_ms, 150)
-    on_exit(fn -> Application.delete_env(:fountain, :conversation_call_timeout_ms) end)
+
+    on_exit(fn ->
+      case previous_timeout do
+        {:ok, value} -> Application.put_env(:fountain, :conversation_call_timeout_ms, value)
+        :error -> Application.delete_env(:fountain, :conversation_call_timeout_ms)
+      end
+    end)
 
     user = insert_verified_user()
     {_key_record, raw_key} = insert_api_key(user)
@@ -23,17 +30,17 @@ defmodule FountainWeb.ConversationCallTimeoutTest do
 
     # The shape of a server whose mailbox is blocked by provisioning:
     # registered under the conversation id, never answering calls.
-    test_pid = self()
-
     stuck =
-      spawn(fn ->
-        Horde.Registry.register(Fountain.ConversationRegistry, conv.id, nil)
-        send(test_pid, :registered)
-        Process.sleep(:infinity)
-      end)
+      start_supervised!(
+        {Task,
+         fn ->
+           {:ok, _} = Horde.Registry.register(Fountain.ConversationRegistry, conv.id, nil)
+           Process.sleep(:infinity)
+         end}
+      )
 
-    assert_receive :registered, 2_000
-    on_exit(fn -> Process.exit(stuck, :kill) end)
+    # Wait for the lookup used by the public calls, not a registration message.
+    assert {:ok, ^stuck} = ConversationServer.await_registered(conv.id, 2_000)
 
     {:ok, conn: authed_with_key(conn, raw_key), user: user, conv: conv}
   end


### PR DESCRIPTION
The timeout fixture sent `:registered` without verifying the registry lookup used by the public calls. If that lookup missed the stand-in, the tests could exercise the missing-server path instead of the timeout path.

Wait for `ConversationServer.await_registered/2` to return the exact supervised stand-in PID before running the existing assertions. The fixture now restores the timeout setting's previous presence and value. The 150 ms call timeout and all five regression tests remain unchanged.

Validation at `4b8bdddf`: scoped `mix precommit apps/fountain/test/fountain_web/controllers/conversation_call_timeout_test.exs` passed every stage with 5 tests and 0 failures. Ten additional runs of the same five tests all passed (50 test executions). `git diff --check` passed. The original full-suite failure discarded its assertion output and has not been reproduced here; this repairs the fixture's readiness and cleanup contract without claiming a confirmed diagnosis of that lost failure.

Fixes #2005
