### PR TITLE
fix(api): make unavailable sandbox errors retryable (#2049)

### DIFF
--- a/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
+++ b/apps/fountain/lib/fountain_web/controllers/fallback_controller.ex
@@ -295,6 +295,15 @@ defmodule FountainWeb.FallbackController do
     })
   end
 
+  # A lifecycle fence can refuse an actor whose sandbox binding just changed.
+  # The request is valid, but must retry after the actor catches up (#2049).
+  def call(conn, {:error, :sandbox_unavailable}) do
+    conn
+    |> put_resp_header("retry-after", "30")
+    |> put_status(:service_unavailable)
+    |> json(%{error: "sandbox_unavailable"})
+  end
+
   # A reapply that would need the machine built again (#1565). 409 rather than
   # 422: the selection is valid, it just cannot be applied to the computer
   # this conversation is already on. `field` says which one forced it, so a

--- a/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
+++ b/apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs
@@ -1135,6 +1135,27 @@ defmodule FountainWeb.ConversationControllerTest do
   end
 
   describe "POST /api/conversations/:conversation_id/terminate" do
+    test "returns a retryable 503 when the actor's sandbox binding is unavailable", %{
+      conn: conn,
+      user: user,
+      raw_key: raw_key
+    } do
+      conv = insert_conversation(user_id: user.id)
+
+      expect(ConversationServer, :terminate_conversation, fn id, _opts ->
+        assert id == conv.id
+        {:error, :sandbox_unavailable}
+      end)
+
+      conn =
+        conn
+        |> authed_with_key(raw_key)
+        |> post("/api/conversations/#{conv.id}/terminate")
+
+      assert %{"error" => "sandbox_unavailable"} = json_response(conn, 503)
+      assert get_resp_header(conn, "retry-after") == ["30"]
+    end
+
     test "returns 204 on success", %{conn: conn, user: user, raw_key: raw_key} do
       conv = insert_conversation(user_id: user.id)
       stub(ConversationServer, :terminate_conversation, fn _id, _opts -> :ok end)

--- a/sdk/conformance/matrix.json
+++ b/sdk/conformance/matrix.json
@@ -64,6 +64,13 @@
       "swift-kit": "yes",
       "elixir": "yes"
     },
+    "error-503-sandbox-unavailable-is-retryable": {
+      "typescript": "yes",
+      "python": "yes",
+      "swift": "yes",
+      "swift-kit": "yes",
+      "elixir": "yes"
+    },
     "error-code-outranks-status-conversation-busy": {
       "typescript": "yes",
       "python": "yes",

--- a/sdk/conformance/scenarios/error-503-sandbox-unavailable-is-retryable.json
+++ b/sdk/conformance/scenarios/error-503-sandbox-unavailable-is-retryable.json
@@ -1,0 +1,72 @@
+{
+  "name": "error-503-sandbox-unavailable-is-retryable",
+  "title": "An unavailable sandbox returns a retryable error with Retry-After",
+  "contract": "errors",
+  "why": "A refused sandbox binding must tell the caller to retry instead of treating a valid request as invalid.",
+  "client": {
+    "api_key": "conformance-key"
+  },
+  "http": [
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/stream",
+        "query": {
+          "streams": "stage",
+          "wait": "false"
+        }
+      },
+      "respond": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "sse": [],
+        "close": "end"
+      }
+    },
+    {
+      "match": {
+        "method": "GET",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/turns"
+      },
+      "respond": {
+        "status": 200,
+        "json": {
+          "data": []
+        }
+      }
+    },
+    {
+      "match": {
+        "method": "POST",
+        "path": "/api/conversations/11111111-2222-3333-4444-555555555555/prompts"
+      },
+      "respond": {
+        "status": 503,
+        "headers": {
+          "retry-after": "30"
+        },
+        "json": {
+          "error": "sandbox_unavailable"
+        }
+      }
+    }
+  ],
+  "steps": [
+    {
+      "op": "send",
+      "conversation_id": "11111111-2222-3333-4444-555555555555",
+      "prompt": "again"
+    }
+  ],
+  "expect": {
+    "error": {
+      "kind": "not_ready",
+      "status": 503,
+      "code": "sandbox_unavailable",
+      "retry_after": 30,
+      "retryable": true
+    }
+  }
+}

--- a/sdk/elixir/CHANGELOG.md
+++ b/sdk/elixir/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.1] - 2026-09-13
+
+- Classify `sandbox_unavailable` as `:not_ready`, preserving the server's `Retry-After` delay for callers retrying a refused sandbox binding (#2049).
+
 ## [0.2.0] - 2026-09-10
 
 - Add `Fountain.Conversation.reapply/2` for `POST /api/conversations/{id}/reapply`: re-select a conversation's agent, environment and vault on the machine it is already running.

--- a/sdk/elixir/lib/fountain/error.ex
+++ b/sdk/elixir/lib/fountain/error.ex
@@ -83,7 +83,11 @@ defmodule Fountain.Error do
   end
 
   defp kind("conversation_busy", _), do: :conversation_busy
-  defp kind(code, _) when code in ~w(provisioning sprite_probe_failed fleet_full), do: :not_ready
+
+  defp kind(code, _)
+       when code in ~w(provisioning sprite_probe_failed fleet_full sandbox_unavailable),
+       do: :not_ready
+
   defp kind("sandbox_quota_exceeded", _), do: :quota_exceeded
 
   defp kind(code, _) when code in ~w(subscription_required insufficient_credits),

--- a/sdk/elixir/lib/fountain/http.ex
+++ b/sdk/elixir/lib/fountain/http.ex
@@ -3,7 +3,7 @@ defmodule Fountain.HTTP do
 
   alias Fountain.{Config, Error}
 
-  @user_agent "fountain-sdk-elixir/0.2.0"
+  @user_agent "fountain-sdk-elixir/0.2.1"
   defstruct [:config, :transport, timeout: 30_000]
 
   @type t :: %__MODULE__{config: Config.t(), transport: module(), timeout: timeout()}

--- a/sdk/elixir/mix.exs
+++ b/sdk/elixir/mix.exs
@@ -1,7 +1,7 @@
 defmodule FountainSdk.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
 
   def project do
     [

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+- Classify `sandbox_unavailable` as `NotReadyError`, preserving the server's `Retry-After` delay for callers retrying a refused sandbox binding (#2049).
+
 ## 0.2.0
 
 - Add `Conversation.reapply()` for `POST /api/conversations/{id}/reapply`: re-select a conversation's agent, environment and vault on the machine it is already running.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fountain-agent-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Run coding agents on Fountain, with real computers, repositories, and credentials."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdk/python/src/fountain/__init__.py
+++ b/sdk/python/src/fountain/__init__.py
@@ -72,4 +72,4 @@ __all__ = [
     "stream_path",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/sdk/python/src/fountain/errors.py
+++ b/sdk/python/src/fountain/errors.py
@@ -169,6 +169,7 @@ def error_for_status(
         "conversation_busy": ConversationBusyError,
         "provisioning": NotReadyError,
         "sprite_probe_failed": NotReadyError,
+        "sandbox_unavailable": NotReadyError,
         "fleet_full": NotReadyError,
         "sandbox_quota_exceeded": QuotaExceededError,
         "subscription_required": SubscriptionRequiredError,

--- a/sdk/python/src/fountain/http.py
+++ b/sdk/python/src/fountain/http.py
@@ -10,7 +10,7 @@ from urllib.request import Request, urlopen
 from .config import ResolvedConfig
 from .errors import AuthError, ConnectionError, error_for_status
 
-USER_AGENT = "fountain-sdk-python/0.2.0"
+USER_AGENT = "fountain-sdk-python/0.2.1"
 
 
 class Response(Protocol):

--- a/sdk/swift/Sources/Fountain/Errors.swift
+++ b/sdk/swift/Sources/Fountain/Errors.swift
@@ -70,7 +70,7 @@ func fountainError(
   let kind: FountainError.Kind
   switch code {
   case "conversation_busy": kind = .conversationBusy
-  case "provisioning", "sprite_probe_failed", "fleet_full": kind = .notReady
+  case "provisioning", "sprite_probe_failed", "fleet_full", "sandbox_unavailable": kind = .notReady
   case "sandbox_quota_exceeded": kind = .quotaExceeded
   case "subscription_required", "insufficient_credits": kind = .subscriptionRequired
   default:

--- a/sdk/swift/Sources/FountainKit/Errors/FountainError.swift
+++ b/sdk/swift/Sources/FountainKit/Errors/FountainError.swift
@@ -188,7 +188,7 @@ extension FountainError {
       case "conversation_busy":
         return .conversationBusy(body)
       case "provisioning", "sprite_probe_failed", "sandbox_probe_failed",
-        "fleet_full", "runner_offline":
+        "fleet_full", "runner_offline", "sandbox_unavailable":
         return .notReady(body, retryAfter: retryAfter)
       case "sandbox_quota_exceeded":
         return .quotaExceeded(body)

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -11,6 +11,12 @@ server releases.
 
 ---
 
+## [1.31.1] - 2026-09-13
+
+### Fixed
+
+- Classify `sandbox_unavailable` as `NotReadyError`, preserving the server's `Retry-After` delay for callers retrying a refused sandbox binding (#2049).
+
 ## [1.31.0] — 2026-09-11
 
 ### Added

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@managoat/fountain-sdk",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@managoat/fountain-sdk",
-      "version": "1.31.0",
+      "version": "1.31.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@managoat/fountain-sdk",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -214,6 +214,7 @@ export function errorForStatus(
       return new ConversationBusyError(message, init);
     case "provisioning":
     case "sprite_probe_failed":
+    case "sandbox_unavailable":
       return new NotReadyError(message, init);
     case "sandbox_quota_exceeded":
       return new QuotaExceededError(message, init);

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.31.0";
+export const USER_AGENT = "fountain-sdk-js/1.31.1";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and


### PR DESCRIPTION
When a conversation actor's sandbox binding changes before termination, the lifecycle fence refuses the operation with `sandbox_unavailable`. `POST /api/conversations/:id/terminate` currently renders that refusal as an undeclared 422. Return its declared 503 with `Retry-After: 30`, preserving the existing error body.

Recognize the same error code as the existing not-ready error in all SDKs. A shared conformance scenario verifies its retryability and retry hint, including SwiftKit, whose generic error fallback previously discarded the hint. The scenario exercises prompt admission, which can return the same refusal through the shared HTTP fallback.

Prepare TypeScript 1.31.1, Python 0.2.1, and Elixir 0.2.1 with matching package versions, User-Agent strings and changelog entries. The registries do not yet contain these versions. TypeScript 1.31.1 should land before the 1.32.0 release planned in #2046; if #2046 lands first, refresh this release metadata before merging. Publishing remains the existing CI action after a future merge.

Validation:
- New HTTP regression fails before the fix: expected 503, received 422. The issue names DELETE; source inspection confirms the affected refusal-returning route is POST terminate.
- Conformance lint passes all 25 scenarios. The new scenario exposed classification failures in the Python, TypeScript and both Swift adapters before the SDK corrections.
- Python: 45 tests passed. TypeScript: 111 tests passed, typecheck and contract verification passed. Swift: 82 tests passed, including both SDK adapters' 25 scenarios. Python contract verification passed.
- Elixir SDK: formatting and warnings-as-errors compilation passed; all 53 tests passed with the committed lockfile, including all 25 conformance scenarios.
- `mix precommit apps/fountain/test/fountain_web/controllers/conversation_controller_test.exs apps/fountain/test/fountain/conversations/termination_actor_fence_test.exs apps/fountain/test/fountain/conversations/termination_client_test.exs apps/fountain/test/fountain_web/schema_guardrail_test.exs` passed all stages on `74aa35ee97f4c96e6ee2e0289f648faec1818f97`: 127 tests, 0 failures. This scoped run includes compile, dependency, formatting, Credo, Dialyzer, Sobelow and production release assembly checks, using Elixir 1.19.2 / OTP 28.3 and an isolated test database.
- Independent source review found no blocking defects in the HTTP mapping, producer paths, SDK classifiers or retry hints.
- Release metadata at `74aa35ee`: TypeScript release guard passed against npm, and the Python gate's version, changelog and PyPI availability checks passed. TypeScript build, typecheck and 111 tests passed. Python's 45 tests passed from source and again from the built 0.2.1 wheel in an isolated installation, including version-token consistency. The Elixir release guard, formatting, warnings-as-errors compilation and all 53 SDK tests passed at this metadata revision; core precommit also passed at this exact head as recorded above.

Fixes #2049
