### PR TITLE
test(swift): synchronize timeout conformance with observed output

### DIFF
--- a/sdk/swift/Sources/FountainKit/Client/APIClient.swift
+++ b/sdk/swift/Sources/FountainKit/Client/APIClient.swift
@@ -41,6 +41,11 @@ public struct RequestOptions: Sendable {
 public struct APIClient: Sendable {
   public let config: FountainConfig
   let transport: any HTTPTransport
+  // Per-client seam for deterministic deadline tests; public clients always
+  // use Task.sleep, with the timeout starting when Run begins following.
+  var sleepForRunDeadline: @Sendable (UInt64) async throws -> Void = {
+    try await Task.sleep(nanoseconds: $0)
+  }
 
   static let userAgent = "fountain-sdk-swiftkit/\(fountainKitVersion)"
 

--- a/sdk/swift/Sources/FountainKit/Client/FountainClient.swift
+++ b/sdk/swift/Sources/FountainKit/Client/FountainClient.swift
@@ -16,6 +16,10 @@ public struct FountainClient: Sendable {
     self.api = APIClient(config: config, transport: transport)
   }
 
+  init(api: APIClient) {
+    self.api = api
+  }
+
   public var config: FountainConfig { api.config }
 
   public var agents: AgentsResource { AgentsResource(client: api) }

--- a/sdk/swift/Sources/FountainKit/Run/Run.swift
+++ b/sdk/swift/Sources/FountainKit/Run/Run.swift
@@ -191,7 +191,7 @@ public final class Run: @unchecked Sendable {
     try await withThrowingTaskGroup(of: Void.self) { group in
       group.addTask { try await self.consume() }
       group.addTask {
-        try await Task.sleep(nanoseconds: UInt64(max(0, timeout) * 1_000_000_000))
+        try await self.client.sleepForRunDeadline(UInt64(max(0, timeout) * 1_000_000_000))
         throw DeadlineReached()
       }
       // Whichever lands first decides; the group cancels the other.

--- a/sdk/swift/Tests/FountainKitTests/ConformanceTests.swift
+++ b/sdk/swift/Tests/FountainKitTests/ConformanceTests.swift
@@ -70,6 +70,44 @@ struct ConformanceTests {
   }
 
   @Test(.timeLimit(.minutes(1)))
+  func missingOutputFailsWithoutHanging() async throws {
+    let scenario = try timeoutScenarioWithoutOutput()
+    let transport = ScriptedTransport(exchanges: scenario.http, holdQuietTail: true)
+    let observations = Observations()
+    let deadline = ObservedOutputDeadline(outputWaitNanoseconds: 100_000_000)
+
+    do {
+      try await drive(scenario, transport: transport, into: observations, deadline: deadline)
+      Issue.record("missing output must fail the harness")
+    } catch let error as Harness {
+      #expect(error.description == "timed out waiting for the scenario's initial text output")
+    }
+    #expect(transport.unmatched.isEmpty)
+  }
+
+  @Test(.timeLimit(.minutes(1)))
+  func cancellingWhileWaitingForOutputSettlesTheRun() async throws {
+    let scenario = try timeoutScenarioWithoutOutput()
+    let transport = ScriptedTransport(exchanges: scenario.http, holdQuietTail: true)
+    let observations = Observations()
+    // The guard cannot rescue this test before its own one-minute limit.
+    let deadline = ObservedOutputDeadline(outputWaitNanoseconds: 120_000_000_000)
+    let task = Task {
+      try await drive(scenario, transport: transport, into: observations, deadline: deadline)
+    }
+    defer { task.cancel() }
+    await deadline.waitUntilWaitingForOutput()
+    task.cancel()
+    do {
+      try await task.value
+      Issue.record("cancelling the harness must cancel its Run")
+    } catch is CancellationError {
+      // Reaching here proves the unstructured Run no longer strands drive.
+    }
+    #expect(transport.unmatched.isEmpty)
+  }
+
+  @Test(.timeLimit(.minutes(1)))
   func publicClientDeadlineDoesNotWaitForOutput() async throws {
     var scenario = try ConformanceSuite.scenario(
       named: "run-timeout-raises-and-keeps-partial-text")
@@ -111,18 +149,41 @@ struct ConformanceTests {
   func deviation(_ deviation: Deviation) {}
 }
 
+private func timeoutScenarioWithoutOutput() throws -> Scenario {
+  var scenario = try ConformanceSuite.scenario(
+    named: "run-timeout-raises-and-keeps-partial-text")
+  var exchange = try #require(scenario.http[1].objectValue)
+  var response = try #require(exchange["respond"]?.objectValue)
+  var frames = try #require(response["sse"]?.arrayValue)
+  // Keep turn-start and the held-open quiet tail; omit only the text event.
+  frames[1] = .string(": no output\n\n")
+  response["sse"] = .array(frames)
+  exchange["respond"] = .object(response)
+  scenario.http[1] = .object(exchange)
+  return scenario
+}
+
 /// Start the scenario's deadline only after the consumer has observed output.
 /// The timeout still expires through Run's real deadline/error path; this
 /// removes the race between a loaded Swift executor and the first SSE frame.
 /// Its matching quiet tail stays open until cancellation, so it cannot win
-/// while the consumer is waiting to be scheduled. The scenario's one-minute
-/// test limit makes missing output a bounded failure rather than a hang.
+/// while the consumer is waiting to be scheduled. A separate guard fails the
+/// harness if output never arrives; test cancellation also cancels the Run.
 private final class ObservedOutputDeadline: Sendable {
   private let output: AsyncStream<Void>
   private let continuation: AsyncStream<Void>.Continuation
+  private let waiting: AsyncStream<Void>
+  private let waitingContinuation: AsyncStream<Void>.Continuation
+  private let outputWaitNanoseconds: UInt64
 
-  init() {
+  init(outputWaitNanoseconds: UInt64 = 10_000_000_000) {
     (output, continuation) = AsyncStream.makeStream()
+    (waiting, waitingContinuation) = AsyncStream.makeStream()
+    self.outputWaitNanoseconds = outputWaitNanoseconds
+  }
+
+  func waitUntilWaitingForOutput() async {
+    for await _ in waiting { break }
   }
 
   func outputObserved() {
@@ -131,7 +192,20 @@ private final class ObservedOutputDeadline: Sendable {
   }
 
   func sleep(nanoseconds: UInt64) async throws {
-    for await _ in output { break }
+    waitingContinuation.yield(())
+    waitingContinuation.finish()
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+        for await _ in self.output { break }
+        try Task.checkCancellation()
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: self.outputWaitNanoseconds)
+        throw Harness("timed out waiting for the scenario's initial text output")
+      }
+      defer { group.cancelAll() }
+      try await group.next()
+    }
     try Task.checkCancellation()
     try await Task.sleep(nanoseconds: nanoseconds)
   }
@@ -142,9 +216,9 @@ private final class ObservedOutputDeadline: Sendable {
 private func drive(
   _ scenario: Scenario,
   transport: ScriptedTransport,
-  into observations: Observations
+  into observations: Observations,
+  deadline: ObservedOutputDeadline = ObservedOutputDeadline()
 ) async throws {
-  let deadline = ObservedOutputDeadline()
   var api = APIClient(config: scenario.config, transport: transport)
   if scenario.name == "run-timeout-raises-and-keeps-partial-text" {
     api.sleepForRunDeadline = { try await deadline.sleep(nanoseconds: $0) }
@@ -208,16 +282,22 @@ private func drive(
         agent: agent,
         timeout: step["timeout_ms"]?.intValue.map { Double($0) / 1000 }
       )
-      for try await event in run.events {
-        if case .text = event { deadline.outputObserved() }
-        observations.events.append(project(event))
-        if case .permission(let request, _) = event,
-          let option = (answers[request.requestID] ?? answers["*"])?.stringValue
-        {
-          try await run.answer(requestID: request.requestID, optionID: option)
+      try await withTaskCancellationHandler {
+        defer { run.cancel() }
+        for try await event in run.events {
+          if case .text = event { deadline.outputObserved() }
+          observations.events.append(project(event))
+          if case .permission(let request, _) = event,
+            let option = (answers[request.requestID] ?? answers["*"])?.stringValue
+          {
+            try await run.answer(requestID: request.requestID, optionID: option)
+          }
         }
+        try Task.checkCancellation()
+        observations.result = project(try await run.value())
+      } onCancel: {
+        run.cancel()
       }
-      observations.result = project(try await run.value())
 
     default:
       throw Harness("this adapter has no op \(op)")

--- a/sdk/swift/Tests/FountainKitTests/ConformanceTests.swift
+++ b/sdk/swift/Tests/FountainKitTests/ConformanceTests.swift
@@ -17,10 +17,12 @@ import Testing
 /// under the `swift-kit` column.
 @Suite("Conformance")
 struct ConformanceTests {
-  @Test("scenario", arguments: ConformanceSuite.runnable)
+  @Test("scenario", .timeLimit(.minutes(1)), arguments: ConformanceSuite.runnable)
   func scenario(_ name: String) async throws {
     let scenario = try ConformanceSuite.scenario(named: name)
-    let transport = ScriptedTransport(exchanges: scenario.http)
+    let transport = ScriptedTransport(
+      exchanges: scenario.http,
+      holdQuietTail: scenario.name == "run-timeout-raises-and-keeps-partial-text")
     let observations = Observations()
 
     do {
@@ -40,6 +42,53 @@ struct ConformanceTests {
             \(problems.map { "  \($0)" }.joined(separator: "\n\n"))
             """))
     }
+  }
+
+  @Test(.timeLimit(.minutes(1)))
+  func timeoutKeepsTextWhenFirstFrameArrivesAfterTheOriginalDeadline() async throws {
+    var scenario = try ConformanceSuite.scenario(
+      named: "run-timeout-raises-and-keeps-partial-text")
+    var exchange = try #require(scenario.http[1].objectValue)
+    var response = try #require(exchange["respond"]?.objectValue)
+    var frames = try #require(response["sse"]?.arrayValue)
+    let first = try #require(frames[0].stringValue)
+    // Reproduce the mechanism on every run: delivery takes twice the
+    // scenario's 300 ms deadline before any output can be consumed.
+    frames[0] = .object(["text": .string(first), "delay_ms": .number(600)])
+    response["sse"] = .array(frames)
+    exchange["respond"] = .object(response)
+    scenario.http[1] = .object(exchange)
+    let transport = ScriptedTransport(exchanges: scenario.http, holdQuietTail: true)
+    let observations = Observations()
+    do {
+      try await drive(scenario, transport: transport, into: observations)
+    } catch {
+      observations.error = error
+    }
+    let problems = check(scenario, observations: observations, transport: transport)
+    #expect(problems.isEmpty, Comment(rawValue: problems.joined(separator: "\n")))
+  }
+
+  @Test(.timeLimit(.minutes(1)))
+  func publicClientDeadlineDoesNotWaitForOutput() async throws {
+    var scenario = try ConformanceSuite.scenario(
+      named: "run-timeout-raises-and-keeps-partial-text")
+    var exchange = try #require(scenario.http[1].objectValue)
+    var response = try #require(exchange["respond"]?.objectValue)
+    response["sse"] = .array([.object(["text": .string(""), "delay_ms": .number(1000)])])
+    exchange["respond"] = .object(response)
+    scenario.http[1] = .object(exchange)
+    let transport = ScriptedTransport(exchanges: scenario.http, holdQuietTail: true)
+    let client = FountainClient(config: scenario.config, transport: transport)
+    let run = try await client.run(
+      "hello", agent: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", timeout: 0.01)
+    do {
+      _ = try await run.value()
+      Issue.record("a silent stream must time out")
+    } catch FountainError.timedOut(let partialText) {
+      #expect(partialText.isEmpty)
+    }
+    #expect(transport.unmatched.isEmpty)
   }
 
   /// A scenario nobody has ruled on is a scenario nobody has read.
@@ -62,6 +111,32 @@ struct ConformanceTests {
   func deviation(_ deviation: Deviation) {}
 }
 
+/// Start the scenario's deadline only after the consumer has observed output.
+/// The timeout still expires through Run's real deadline/error path; this
+/// removes the race between a loaded Swift executor and the first SSE frame.
+/// Its matching quiet tail stays open until cancellation, so it cannot win
+/// while the consumer is waiting to be scheduled. The scenario's one-minute
+/// test limit makes missing output a bounded failure rather than a hang.
+private final class ObservedOutputDeadline: Sendable {
+  private let output: AsyncStream<Void>
+  private let continuation: AsyncStream<Void>.Continuation
+
+  init() {
+    (output, continuation) = AsyncStream.makeStream()
+  }
+
+  func outputObserved() {
+    continuation.yield(())
+    continuation.finish()
+  }
+
+  func sleep(nanoseconds: UInt64) async throws {
+    for await _ in output { break }
+    try Task.checkCancellation()
+    try await Task.sleep(nanoseconds: nanoseconds)
+  }
+}
+
 // MARK: - driving
 
 private func drive(
@@ -69,7 +144,12 @@ private func drive(
   transport: ScriptedTransport,
   into observations: Observations
 ) async throws {
-  let client = FountainClient(config: scenario.config, transport: transport)
+  let deadline = ObservedOutputDeadline()
+  var api = APIClient(config: scenario.config, transport: transport)
+  if scenario.name == "run-timeout-raises-and-keeps-partial-text" {
+    api.sleepForRunDeadline = { try await deadline.sleep(nanoseconds: $0) }
+  }
+  let client = FountainClient(api: api)
 
   for step in scenario.steps {
     guard let op = step["op"]?.stringValue else {
@@ -129,6 +209,7 @@ private func drive(
         timeout: step["timeout_ms"]?.intValue.map { Double($0) / 1000 }
       )
       for try await event in run.events {
+        if case .text = event { deadline.outputObserved() }
         observations.events.append(project(event))
         if case .permission(let request, _) = event,
           let option = (answers[request.requestID] ?? answers["*"])?.stringValue

--- a/sdk/swift/Tests/FountainKitTests/ScriptedTransport.swift
+++ b/sdk/swift/Tests/FountainKitTests/ScriptedTransport.swift
@@ -29,13 +29,15 @@ struct RecordedRequest: Sendable {
 /// hanging it.
 final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
   private let exchanges: [JSONValue]
+  private let holdQuietTail: Bool
   private let lock = NSLock()
   private var consumed = Set<Int>()
   private var seen: [RecordedRequest] = []
   private var unanticipated: [RecordedRequest] = []
 
-  init(exchanges: [JSONValue]) {
+  init(exchanges: [JSONValue], holdQuietTail: Bool = false) {
     self.exchanges = exchanges
+    self.holdQuietTail = holdQuietTail
   }
 
   var requests: [RecordedRequest] {
@@ -80,7 +82,15 @@ final class ScriptedTransport: HTTPTransport, @unchecked Sendable {
         for chunk in chunks {
           let text = chunk.stringValue ?? chunk["text"]?.stringValue ?? ""
           if let delay = chunk["delay_ms"]?.intValue, delay > 0 {
-            try? await Task.sleep(nanoseconds: UInt64(delay) * 1_000_000)
+            if self.holdQuietTail && text.isEmpty {
+              // This fixture represents a stream that remains quiet beyond
+              // the run deadline. Let cancellation end it, even if processing
+              // the preceding output takes longer than its scripted delay.
+              let quiet = AsyncStream<Void> { _ in }
+              for await _ in quiet {}
+            } else {
+              try? await Task.sleep(nanoseconds: UInt64(delay) * 1_000_000)
+            }
           }
           if Task.isCancelled { return continuation.finish() }
           if !text.isEmpty { continuation.yield(Data(text.utf8)) }


### PR DESCRIPTION
The timeout conformance scenario could lose partial text when its 300 ms deadline expired before the executor consumed the first output frame. Start this scenario's deadline after the consumer observes text and hold the quiet fixture tail open until cancellation. A per-client internal sleeper seam preserves the public client's normal deadline behavior.

The harness now gives initial output a separate 10-second guard. Missing output throws an explicit harness error, and cancellation of the test cancels and settles its Run before any wait for the result can hang. The event loop and result wait share the cancellation handler; deferred cleanup also handles early errors. This addresses the adversarial review's demonstrated suite stall.

Fixes #1723.

Validation:

- All 86 Swift tests passed with warnings as errors, including nine conformance tests and the new missing-output and cancellation regressions.
- Delaying the first frame by 600 ms still retains partial text. The public-client silent-stream test still times out without waiting for output.
- The independent reviewer repeated the original missing-output reproduction: it now exits with the expected harness failure after 10.678 seconds, instead of surviving the 60-second test limit and requiring an external kill at 80 seconds.
- A delayed-consumer control also completed correctly when the guard expired before the stream request started.
- Strict recursive Swift format lint and the release build passed.
- Scoped `mix precommit apps/fountain/test/fountain/extension_composition_test.exs` passed every gate and all 24 tests in an isolated build/database.

The additional correction changes only the conformance harness. No SDK release or public API change is required.
