### PR TITLE
Fix runner LiveView heartbeat ownership and teardown

### DIFF
--- a/apps/fountain/test/fountain_web/live/runners_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/runners_live_test.exs
@@ -14,21 +14,39 @@ defmodule FountainWeb.RunnersLiveTest do
       Runners.register(user.id, %{"name" => "mini", "os" => "darwin", "arch" => "arm64"})
 
     {:ok, daemon} = FakeDaemon.start(online.id, meta: %{user_id: user.id}, name: "mini")
-    on_exit(fn -> FakeDaemon.stop(daemon) end)
+    # The socket is a GenServer, so unlike a Task it does not inherit this
+    # async test's SQL Sandbox allowance through $callers.
+    Ecto.Adapters.SQL.Sandbox.allow(Fountain.Repo, self(), daemon.socket)
+    socket_ref = Process.monitor(daemon.socket)
+    daemon_ref = Process.monitor(daemon.daemon)
 
-    conn = login_user(conn, user)
-    {:ok, lv, html} = live(conn, ~p"/account/runners")
+    try do
+      conn = login_user(conn, user)
+      {:ok, lv, html} = live(conn, ~p"/account/runners")
 
-    assert html =~ "laptop"
-    assert html =~ "lap.local"
-    assert html =~ "mini"
-    assert html =~ "darwin · arm64"
-    assert html =~ "online"
-    assert html =~ "fountain runner"
+      assert html =~ "laptop"
+      assert html =~ "lap.local"
+      assert html =~ "mini"
+      assert html =~ "darwin · arm64"
+      assert html =~ "online"
+      assert html =~ "fountain runner"
 
-    lv |> element("#runner-#{offline.id} button", "Forget") |> render_click()
-    refute Runners.get_runner(offline.id, user.id)
-    refute render(lv) =~ "lap.local"
+      lv |> element("#runner-#{offline.id} button", "Forget") |> render_click()
+      refute Runners.get_runner(offline.id, user.id)
+      refute render(lv) =~ "lap.local"
+
+      # A real heartbeat writes through the socket's sandbox allowance. Drain
+      # it before cleanup, without waiting for the periodic 20-second timer.
+      send(daemon.socket, :heartbeat)
+      :sys.get_state(daemon.socket)
+      assert Runners.get_runner(online.id, user.id).last_seen_at
+    after
+      # Stop from the process FakeDaemon.start linked to, while its SQL
+      # Sandbox access is still alive. on_exit runs in a different process.
+      FakeDaemon.stop(daemon)
+      assert_receive {:DOWN, ^socket_ref, :process, _, _}, 5_000
+      assert_receive {:DOWN, ^daemon_ref, :process, _, _}, 5_000
+    end
   end
 
   test "shows the empty state and the start instructions", %{conn: conn} do


### PR DESCRIPTION
The runner socket in `RunnersLiveTest` had no SQL Sandbox allowance: explicitly delivering its heartbeat reproduced `DBConnection.OwnershipError` in `Runners.touch/1` while the test was still alive. Grant the socket access to the test's connection and exercise that heartbeat directly. Stop the fake daemon in `try/after` from its linked starter, then await both socket and daemon exits before the test ends.

Fixes #1909.

Validation: the forced heartbeat failed before the allowance fix (3 tests, 1 failure). After the fix, `mix test test/fountain_web/live/runners_live_test.exs --seed 0 --repeat-until-failure 20` completed 21 consecutive runs (63 tests, 0 failures), using an isolated PostgreSQL database and OTP 28.3 / Elixir 1.19.2.

`mix precommit apps/fountain/test/fountain_web/live/runners_live_test.exs` passed compile, formatting, Credo, Dialyzer, Sobelow, prod release assembly, and the 3-test suite.

Combined validation: all seven flake fixes were merged locally with main at `da7b9bd8` on an unpublished integration branch (`11b19a13`). The full umbrella run used the final patched Mix loader at seed `836199` and reported 5,921 Fountain tests and 6 doctests, 144 Buzz tests and 33 Support tests, with 0 failures and 2 existing skips (7 excluded). The earlier 35-file application integration run also passed all 480 tests. No PR was merged for this validation.
