### PR TITLE
fix(ci): prevent Mix build locks from waiting on their own reused ports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Unified diffs use a single space to mark an empty context line.
+scripts/ci/mix-lock-15765.patch whitespace=-blank-at-eol

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,13 @@ jobs:
           elixir-version: "1.19.2"
           otp-version: "28.3"
 
+      - name: Backport the pinned Mix lock fix
+        run: scripts/ci/mix-lock-backport.sh --install
+
+      - name: Mix lock backport preserves port reuse and cross-VM exclusion
+        if: ${{ matrix.partition == 1 }}
+        run: elixir scripts/ci/mix-lock-backport-test.exs
+
       - name: Timing collection preserves ExUnit execution
         if: ${{ matrix.partition == 1 }}
         run: elixir scripts/ci/timing-formatter-test.exs
@@ -448,6 +455,9 @@ jobs:
           elixir-version: "1.19.2"
           otp-version: "28.3"
 
+      - name: Backport the pinned Mix lock fix
+        run: scripts/ci/mix-lock-backport.sh --install
+
       - name: Download coverage exports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -531,6 +541,9 @@ jobs:
         with:
           elixir-version: "1.19.2"
           otp-version: "28.3"
+
+      - name: Backport the pinned Mix lock fix
+        run: scripts/ci/mix-lock-backport.sh --install
 
       # Job-scoped keys — see the note in `test`.
       - name: Restore deps cache
@@ -651,6 +664,9 @@ jobs:
         with:
           elixir-version: "1.19.2"
           otp-version: "28.3"
+
+      - name: Backport the pinned Mix lock fix
+        run: scripts/ci/mix-lock-backport.sh --install
 
       # Job-scoped keys — see the note in `test`.
       - name: Restore deps cache
@@ -1375,6 +1391,9 @@ jobs:
           elixir-version: "1.19.2"
           otp-version: "28.3"
 
+      - name: Backport the pinned Mix lock fix
+        run: scripts/ci/mix-lock-backport.sh --install
+
       - name: Restore deps cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
@@ -1733,6 +1752,9 @@ jobs:
         with:
           elixir-version: "1.19.2"
           otp-version: "28.3"
+
+      - name: Backport the pinned Mix lock fix
+        run: scripts/ci/mix-lock-backport.sh --install
 
       # Shares the `test` job's cache keys on purpose. The warning against
       # sharing a key (see the `test` job) is about two jobs racing to save

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,10 @@ jobs:
         if: ${{ matrix.partition == 1 }}
         run: elixir scripts/ci/timing-formatter-test.exs
 
+      - name: Mix stall diagnostics capture lock holders and waiters
+        if: ${{ matrix.partition == 1 }}
+        run: elixir scripts/ci/mix-diagnostics-test.exs
+
       # Cache keys carry the job name. `test` and `checks` build different
       # trees — this one only ever compiles :test, while `checks` additionally
       # builds :dev for dialyzer and :prod for the release — and a shared key
@@ -355,7 +359,13 @@ jobs:
           exit 1
 
       - name: Set up database
-        run: mix ecto.create --quiet && mix ecto.migrate --quiet
+        # #1997 stalled inside Mix before tests began. Capture the live lock
+        # holders and process tree before the unchanged job timeout cancels it.
+        env:
+          MIX_DIAGNOSTICS: "1"
+        run: |
+          elixir -r scripts/ci/mix-diagnostics.exs -S mix ecto.create --quiet
+          elixir -r scripts/ci/mix-diagnostics.exs -S mix ecto.migrate --quiet
 
       # Coverage instrumentation is free here — measured at 128.8s with cover
       # against 128.6s without, on the same machine. Running the suite bare on

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -248,10 +248,12 @@ reporter to distinguish any future stall.
 source SHA256, applies the unchanged upstream patch to a temporary copy,
 verifies the resulting SHA256, and compiles an isolated ebin. It edits no
 installed toolchain and fetches nothing. `--install` exports `ERL_AFLAGS`
-through `GITHUB_ENV`, preserving existing flags. An Erlang bootstrap explicitly
+through `GITHUB_ENV`, preserving existing flags. An Erlang `-eval` explicitly
 loads the patched module before Elixir starts: adding `-pa` alone is
 insufficient because Elixir later prepends its own Mix path. A module-origin
 check and the cross-VM regression verify that the fix reaches child VMs.
+The preload also runs under embedded release boot, which disables autoloading
+and cannot start a custom `-s` bootstrap module from an added code path.
 
 For isolated local verification, wrap a command with the same script:
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -223,3 +223,53 @@ The `Alert rules` workflow runs `scripts/test-alerts.py` with Prometheus
 replica aggregation, failure thresholds, counter resets, absent series, low
 traffic, and first-output alert hold time. Run the same command locally
 after changing `deploy/k8s/prometheusrule.yaml`.
+
+## Pinned Mix lock backport
+
+Core CI jobs on Elixir 1.19.2 install the exact upstream
+[Mix lock fix #15765](https://github.com/elixir-lang/elixir/pull/15765)
+before invoking Mix. The patch is Apache 2.0 (see
+[mix-lock-15765.patch.license](mix-lock-15765.patch.license)).
+
+Pinned Mix leaves its first `port_P` file hard-linked to `lock_0` after
+unlocking. If the OS reassigns that port to the next listener, recreating
+`port_P` overwrites `lock_0` with the current process's port. Mix then probes
+its own listener and waits for itself indefinitely. The regression reproduces
+this with real TCP sockets by asking the allocator to reuse its first port.
+The backport also handles reassignment after an owner crashes and retains
+mutual exclusion between separate OS processes.
+
+This is a concrete mechanism consistent with #1997's wait on PID 2770 after
+compiling the core app. The historical log did not capture lock files or
+stacks, so it cannot establish that exact interleaving. Keep the diagnostic
+reporter to distinguish any future stall.
+
+`scripts/ci/mix-lock-backport.sh` verifies Elixir 1.19.2 and the original
+source SHA256, applies the unchanged upstream patch to a temporary copy,
+verifies the resulting SHA256, and compiles an isolated ebin. It edits no
+installed toolchain and fetches nothing. `--install` exports `ERL_AFLAGS`
+through `GITHUB_ENV`, preserving existing flags. An Erlang bootstrap explicitly
+loads the patched module before Elixir starts: adding `-pa` alone is
+insufficient because Elixir later prepends its own Mix path. A module-origin
+check and the cross-VM regression verify that the fix reaches child VMs.
+
+For isolated local verification, wrap a command with the same script:
+
+```sh
+scripts/ci/mix-lock-backport.sh elixir scripts/ci/mix-lock-backport-test.exs
+scripts/ci/mix-lock-backport.sh mix ecto.create --quiet
+```
+
+Use a dedicated build tree with no concurrent unpatched Mix process. Upstream
+changed the lock namespace to `mix_lock_v2_user`, so patched and unpatched VMs
+do not coordinate on a shared build directory. The local wrapper removes its
+temporary ebin when the command exits; it is intended for finite verification
+commands. CI's installation persists for the whole job, including nested Mix
+commands and release checks. The separate SDK matrix retains its toolchains.
+
+**Retirement:** remove the wrapper, patch and CI installation steps when the
+pinned Elixir release contains #15765 and these regressions pass against its
+native module. As checked on 2026-09-13, neither 1.19.6 nor 1.20.4 contains the
+fix; a patch-version bump alone does not address this race. Version and source
+fingerprint guards intentionally fail when the toolchain changes, requiring
+that review rather than silently patching a different implementation.

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -11,6 +11,24 @@ older pending validation or wait behind an unrelated run. Superseded PR runs
 still cancel. Image builds retain the built-ancestor diff, which includes all
 image-affecting changes since the last built ancestor.
 
+## Database setup stalls
+
+The partition jobs load `mix-diagnostics.exs` before running database setup.
+After each minute, it prints the VM's OS PID, Mix stack traces, lock holders
+and an OS process tree. This captures a stalled compiler before the job's
+existing timeout cancels it (#1997). It does not retry commands, disable
+locking or change timeouts. A setup that finishes within a minute adds no
+diagnostic output.
+
+Process messages, dictionary values, environment variables and command
+arguments are omitted. Compare the PID in Mix's lock-wait message with the
+reported VM PID and process tree to distinguish a second VM from a wait
+inside the same VM. Reproduce locally with the same build cache and command:
+
+```sh
+MIX_DIAGNOSTICS=1 MIX_ENV=test elixir -r scripts/ci/mix-diagnostics.exs -S mix ecto.migrate --quiet
+```
+
 ## Activate required checks after merging
 
 The repository ruleset is external state, so opening this PR does not change

--- a/scripts/ci/mix-diagnostics-test.exs
+++ b/scripts/ci/mix-diagnostics-test.exs
@@ -1,0 +1,72 @@
+Code.require_file("mix-diagnostics.exs", __DIR__)
+ExUnit.start()
+Application.ensure_all_started(:mix)
+
+defmodule Fountain.CI.MixDiagnosticsTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureIO
+  alias Fountain.CI.MixDiagnostics
+
+  test "reports a real lock holder and waiter without exposing their process dictionaries" do
+    parent = self()
+    key = "fountain-ci-diagnostics-#{System.pid()}-#{System.unique_integer([:positive])}"
+
+    holder =
+      spawn(fn ->
+        Process.put(:credentials, "do-not-log-this-secret")
+
+        Mix.Sync.Lock.with_lock(key, fn ->
+          send(parent, :ready)
+          receive do: (:stop -> :ok)
+        end)
+      end)
+
+    holder_ref = Process.monitor(holder)
+
+    try do
+      assert_receive :ready, 5_000
+
+      waiter =
+        spawn(fn ->
+          Mix.Sync.Lock.with_lock(key, fn -> :ok end,
+            on_taken: fn _ -> send(parent, :waiting) end
+          )
+        end)
+
+      waiter_ref = Process.monitor(waiter)
+
+      try do
+        assert_receive :waiting, 5_000
+        snapshot = MixDiagnostics.snapshot()
+        assert snapshot =~ inspect(holder)
+        assert snapshot =~ inspect(waiter)
+        assert snapshot =~ "Mix.Sync.Lock"
+        assert snapshot =~ "OS pid #{System.pid()}"
+        assert snapshot =~ "OS process tree"
+        refute snapshot =~ "do-not-log-this-secret"
+      after
+        send(holder, :stop)
+        assert_receive {:DOWN, ^waiter_ref, :process, ^waiter, :normal}, 5_000
+      end
+    after
+      send(holder, :stop)
+      assert_receive {:DOWN, ^holder_ref, :process, ^holder, :normal}, 5_000
+    end
+  end
+
+  test "periodic diagnostics stop without affecting the caller" do
+    output =
+      capture_io(:stderr, fn ->
+        pid = MixDiagnostics.start(1)
+        ref = Process.monitor(pid)
+
+        # Wait on the actual write, not on a scheduler sleep.
+        :erlang.trace(pid, true, [:send])
+        assert_receive {:trace, ^pid, :send, {:io_request, _, _, _}, _}, 5_000
+        send(pid, :stop)
+        assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 5_000
+      end)
+
+    assert output =~ "Mix setup still running"
+  end
+end

--- a/scripts/ci/mix-diagnostics.exs
+++ b/scripts/ci/mix-diagnostics.exs
@@ -1,0 +1,64 @@
+defmodule Fountain.CI.MixDiagnostics do
+  @moduledoc false
+
+  # Loaded before Mix, so a compiler lock stall cannot prevent diagnostics.
+  # No application env, process messages, dictionary values or argv are logged.
+  def start(interval_ms \\ 60_000) do
+    spawn(fn -> loop(interval_ms) end)
+  end
+
+  defp loop(interval_ms) do
+    receive do
+      :stop -> :ok
+    after
+      interval_ms ->
+        IO.puts(:stderr, snapshot())
+        loop(interval_ms)
+    end
+  end
+
+  def snapshot do
+    processes =
+      for pid <- Process.list(),
+          info = Process.info(pid, [:current_stacktrace, :dictionary, :registered_name, :status]),
+          info != nil,
+          relevant?(info) do
+        locks =
+          for {{Mix.Sync.Lock, path}, true} <- info[:dictionary], do: path
+
+        # Frame arguments can contain credentials. Keep only function arities.
+        stack = Enum.map(info[:current_stacktrace], &frame/1)
+        inspect({pid, info[:registered_name], info[:status], locks, stack}, limit: :infinity)
+      end
+
+    "Mix setup still running: OS pid #{System.pid()}, cwd #{File.cwd!()}\n" <>
+      Enum.join(processes, "\n") <>
+      "\nOS process tree (pid, ppid, status, executable):\n" <>
+      process_tree()
+  end
+
+  defp relevant?(info) do
+    Enum.any?(info[:dictionary], &match?({{Mix.Sync.Lock, _}, true}, &1)) or
+      Enum.any?(info[:current_stacktrace], fn {module, _, _, _} ->
+        String.starts_with?(Atom.to_string(module), "Elixir.Mix.")
+      end)
+  end
+
+  defp frame({module, function, args, location}) when is_list(args),
+    do: {module, function, length(args), location}
+
+  defp frame(frame), do: frame
+
+  defp process_tree do
+    case System.find_executable("ps") do
+      nil ->
+        "ps unavailable"
+
+      executable ->
+        {output, _status} = System.cmd(executable, ["-axo", "pid=,ppid=,stat=,comm="])
+        output
+    end
+  end
+end
+
+if System.get_env("MIX_DIAGNOSTICS") == "1", do: Fountain.CI.MixDiagnostics.start()

--- a/scripts/ci/mix-lock-15765.patch
+++ b/scripts/ci/mix-lock-15765.patch
@@ -1,0 +1,110 @@
+diff --git a/lib/mix/lib/mix/sync/lock.ex b/lib/mix/lib/mix/sync/lock.ex
+index 7fa939f5126..dd8e8a890b5 100644
+--- a/lib/mix/lib/mix/sync/lock.ex
++++ b/lib/mix/lib/mix/sync/lock.ex
+@@ -131,7 +131,7 @@ defmodule Mix.Sync.Lock do
+ 
+   defp base_path do
+     # We include user in the dir to avoid permission conflicts across users
+-    Path.join(System.tmp_dir!(), "mix_lock_user#{Mix.Utils.detect_user_id!()}")
++    Path.join(System.tmp_dir!(), "mix_lock_v2_user#{Mix.Utils.detect_user_id!()}")
+   end
+ 
+   defp lock_disabled?(), do: System.get_env("MIX_OS_CONCURRENCY_LOCK") in ~w(0 false)
+@@ -174,13 +174,15 @@ defmodule Mix.Sync.Lock do
+     port_path = Path.join(path, "port_#{port}")
+     os_pid = System.pid()
+ 
+-    switch_file_create!(port_path, encode_lock_info(port, os_pid))
++    # We remove the port file if it exists, since it may be hard
++    # linked to a lock_N file of a crashed process, and we do not
++    # want to affect that lock_N file. We can do that, because we
++    # own the port now.
++    file_rm_if_exists!(port_path)
+ 
+-    case grab_lock(path, port_path, 0) do
+-      {:ok, 0} ->
+-        # We grabbed lock_0, so all good
+-        %{socket: socket, path: path}
++    switch_file_create!(port_path, encode_lock_info(port, os_pid))
+ 
++    case grab_lock(path, port, 0) do
+       {:ok, _n} ->
+         # We grabbed lock_1+, so we need to replace lock_0 and clean up
+         take_over(path, port, os_pid)
+@@ -197,7 +199,8 @@ defmodule Mix.Sync.Lock do
+     end
+   end
+ 
+-  defp grab_lock(path, port_path, n) do
++  defp grab_lock(path, port, n) do
++    port_path = Path.join(path, "port_#{port}")
+     lock_path = Path.join(path, "lock_#{n}")
+ 
+     case File.ln(port_path, lock_path) do
+@@ -205,12 +208,12 @@ defmodule Mix.Sync.Lock do
+         {:ok, n}
+ 
+       {:error, :eexist} ->
+-        case probe(lock_path) do
++        case probe(lock_path, port) do
+           {:ok, probe_socket, os_pid} ->
+             {:taken, probe_socket, os_pid}
+ 
+           {:error, _reason} ->
+-            grab_lock(path, port_path, n + 1)
++            grab_lock(path, port, n + 1)
+         end
+ 
+       {:error, :enoent} ->
+@@ -241,8 +244,9 @@ defmodule Mix.Sync.Lock do
+     end
+   end
+ 
+-  defp probe(port_path) do
++  defp probe(port_path, own_port) do
+     with {:ok, port, os_pid} <- fetch_probe_port(port_path),
++         :ok <- ensure_peer_port(port, own_port),
+          {:ok, socket} <- connect(port),
+          {:ok, socket} <- await_probe_data(socket) do
+       {:ok, socket, os_pid}
+@@ -262,6 +266,11 @@ defmodule Mix.Sync.Lock do
+     end
+   end
+ 
++  # The OS may have re-assigned a dead peer port to us, in which case
++  # we do not attempt to connect to ourselves.
++  defp ensure_peer_port(own_port, own_port), do: {:error, :same_port_as_own}
++  defp ensure_peer_port(_port, _own_port), do: :ok
++
+   defp connect(port) do
+     # On Windows connecting to an unbound port takes a few seconds to
+     # fail, so instead we shortcut the check by attempting a listen,
+@@ -400,6 +409,9 @@ defmodule Mix.Sync.Lock do
+   # Note that file content can be replaced only by a single process
+   # at a time.
+   #
++  # Note that this function is not atomic, only switch_file_replace!
++  # is atomic, and this is all we need.
++  #
+   # [1]: https://github.com/elixir-lang/elixir/pull/14793#issuecomment-3338665065
+   defp switch_file_create!(path, content) do
+     data = <<0, content::binary, content::binary>>
+@@ -466,4 +478,17 @@ defmodule Mix.Sync.Lock do
+         raise File.Error, reason: reason, action: "write to file at position"
+     end
+   end
++
++  defp file_rm_if_exists!(path) do
++    case File.rm(path) do
++      :ok ->
++        :ok
++
++      {:error, :enoent} ->
++        :ok
++
++      {:error, reason} ->
++        raise File.Error, reason: reason, action: "remove file", path: path
++    end
++  end
+ end

--- a/scripts/ci/mix-lock-15765.patch.license
+++ b/scripts/ci/mix-lock-15765.patch.license
@@ -1,0 +1,6 @@
+SPDX-FileCopyrightText: 2021 The Elixir Team
+SPDX-License-Identifier: Apache-2.0
+
+Exact patch from https://github.com/elixir-lang/elixir/pull/15765
+Merged as b703302cd1fc91dd1b2df51659daf9b8d6053776.
+The Apache 2.0 license text is included at ../../cli/LICENSE.

--- a/scripts/ci/mix-lock-backport-test.exs
+++ b/scripts/ci/mix-lock-backport-test.exs
@@ -1,0 +1,190 @@
+ExUnit.start()
+Application.ensure_all_started(:mix)
+
+source = Path.join([:code.lib_dir(:mix), "lib/mix/sync/lock.ex"]) |> File.read!()
+patch_dir = :code.which(Mix.Sync.Lock) |> List.to_string() |> Path.dirname() |> Path.dirname()
+patched_source = Path.join(patch_dir, "lib/mix/lib/mix/sync/lock.ex") |> File.read!()
+
+# Control only the OS port allocator: the first listen chooses a real free
+# port, and the second listen requests that same port after the first closes.
+# Both versions still use their actual TCP probes, hardlinks and lock code.
+for {module, text} <- [
+      {Fountain.CI.OldMixLock, source},
+      {Fountain.CI.FixedMixLock, patched_source}
+    ] do
+  for needle <- [
+        "defmodule Mix.Sync.Lock do",
+        ":gen_tcp.listen(0, @listen_opts)",
+        "{:ok, port} ->\n          {:ok, socket, port}"
+      ] do
+    unless length(String.split(text, needle)) == 2,
+      do: raise("allocator instrumentation no longer matches the audited source")
+  end
+
+  text =
+    text
+    |> String.replace("defmodule Mix.Sync.Lock do", "defmodule #{inspect(module)} do")
+    |> String.replace(
+      ":gen_tcp.listen(0, @listen_opts)",
+      ":gen_tcp.listen(Process.get(:test_listener_port, 0), @listen_opts)"
+    )
+    |> String.replace(
+      "{:ok, port} ->\n          {:ok, socket, port}",
+      "{:ok, port} ->\n          Process.put(:test_listener_port, port)\n          {:ok, socket, port}"
+    )
+
+  Code.compile_string(text)
+end
+
+defmodule Fountain.CI.MixLockBackportTest do
+  use ExUnit.Case, async: false
+
+  alias Fountain.CI.{FixedMixLock, OldMixLock}
+
+  defp key do
+    "fountain-backport-test-#{System.pid()}-#{System.unique_integer([:positive])}"
+  end
+
+  defp cleanup(key, version) do
+    hash = key |> :erlang.md5() |> Base.url_encode64(padding: false)
+    root = "mix_lock_#{version}user#{Mix.Utils.detect_user_id!()}"
+    File.rm_rf!(Path.join([System.tmp_dir!(), root, hash]))
+  end
+
+  defp stop(pid, ref) do
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _}, 5_000
+  end
+
+  test "pinned Mix deadlocks on its own reused port, the exact backport acquires" do
+    for {module, version, expected} <- [
+          {OldMixLock, "", :self_wait},
+          {FixedMixLock, "v2_", :acquired}
+        ] do
+      key = key()
+      parent = self()
+
+      {pid, ref} =
+        spawn_monitor(fn ->
+          module.with_lock(key, fn -> :ok end)
+          send(parent, {:reusing_port, Process.get(:test_listener_port)})
+
+          module.with_lock(key, fn -> send(parent, :acquired) end,
+            on_taken: fn owner -> send(parent, {:self_wait, owner}) end
+          )
+        end)
+
+      try do
+        assert_receive {:reusing_port, port}, 5_000
+        assert is_integer(port) and port > 0
+
+        case expected do
+          :self_wait ->
+            os_pid = System.pid()
+            assert_receive {:self_wait, ^os_pid}, 5_000
+            refute_received :acquired
+
+          :acquired ->
+            assert_receive :acquired, 5_000
+            refute_received {:self_wait, _}
+        end
+      after
+        stop(pid, ref)
+        cleanup(key, version)
+      end
+    end
+  end
+
+  test "backport takes over a crashed owner's port when the OS reassigns it" do
+    key = key()
+    parent = self()
+
+    {owner, owner_ref} =
+      spawn_monitor(fn ->
+        FixedMixLock.with_lock(key, fn ->
+          send(parent, {:port, Process.get(:test_listener_port)})
+          Process.sleep(:infinity)
+        end)
+      end)
+
+    try do
+      assert_receive {:port, port}, 5_000
+      stop(owner, owner_ref)
+
+      {pid, ref} =
+        spawn_monitor(fn ->
+          Process.put(:test_listener_port, port)
+          FixedMixLock.with_lock(key, fn -> send(parent, :acquired) end)
+        end)
+
+      try do
+        assert_receive :acquired, 5_000
+      after
+        stop(pid, ref)
+      end
+    after
+      if Process.alive?(owner), do: stop(owner, owner_ref)
+      cleanup(key, "v2_")
+    end
+  end
+
+  test "ordinary patched child VMs inherit the fix and preserve mutual exclusion" do
+    key = key()
+    beam = :code.which(Mix.Sync.Lock) |> List.to_string()
+
+    owner =
+      child("""
+      Application.ensure_all_started(:mix)
+      IO.puts("module:" <> to_string(:code.which(Mix.Sync.Lock)))
+      Mix.Sync.Lock.with_lock(#{inspect(key)}, fn ->
+        IO.puts("held:" <> System.pid())
+        IO.gets("")
+      end)
+      """)
+
+    try do
+      assert_receive {^owner, {:data, {:eol, "module:" <> ^beam}}}, 5_000
+      assert_receive {^owner, {:data, {:eol, "held:" <> owner_pid}}}, 5_000
+
+      waiter =
+        child("""
+        Application.ensure_all_started(:mix)
+        IO.puts("module:" <> to_string(:code.which(Mix.Sync.Lock)))
+        Mix.Sync.Lock.with_lock(#{inspect(key)}, fn -> IO.puts("acquired") end,
+          on_taken: fn owner -> IO.puts("waiting:" <> owner) end)
+        """)
+
+      try do
+        assert_receive {^waiter, {:data, {:eol, "module:" <> ^beam}}}, 5_000
+        assert_receive {^waiter, {:data, {:eol, "waiting:" <> ^owner_pid}}}, 5_000
+        refute_received {^waiter, {:data, {:eol, "acquired"}}}
+        Port.command(owner, "release\n")
+        assert_receive {^waiter, {:data, {:eol, "acquired"}}}, 5_000
+        assert_receive {^owner, {:exit_status, 0}}, 5_000
+        assert_receive {^waiter, {:exit_status, 0}}, 5_000
+      after
+        close(owner)
+        close(waiter)
+      end
+    after
+      close(owner)
+      cleanup(key, "v2_")
+    end
+  end
+
+  defp child(code) do
+    executable = System.find_executable("elixir") |> String.to_charlist()
+
+    Port.open({:spawn_executable, executable}, [
+      :binary,
+      :exit_status,
+      :stderr_to_stdout,
+      {:line, 4096},
+      args: ["-e", code]
+    ])
+  end
+
+  defp close(port) do
+    if Port.info(port) != nil, do: Port.close(port)
+  end
+end

--- a/scripts/ci/mix-lock-backport-test.exs
+++ b/scripts/ci/mix-lock-backport-test.exs
@@ -172,6 +172,32 @@ defmodule Fountain.CI.MixLockBackportTest do
     end
   end
 
+  test "inherited preload flags also allow embedded release boot" do
+    executable = System.find_executable("erl") |> String.to_charlist()
+
+    child =
+      Port.open({:spawn_executable, executable}, [
+        :binary,
+        :exit_status,
+        :stderr_to_stdout,
+        {:line, 4096},
+        args: [
+          "-mode",
+          "embedded",
+          "-noshell",
+          "-eval",
+          "io:format(\"embedded started~n\"), halt()."
+        ]
+      ])
+
+    try do
+      assert_receive {^child, {:data, {:eol, "embedded started"}}}, 5_000
+      assert_receive {^child, {:exit_status, 0}}, 5_000
+    after
+      close(child)
+    end
+  end
+
   defp child(code) do
     executable = System.find_executable("elixir") |> String.to_charlist()
 

--- a/scripts/ci/mix-lock-backport.sh
+++ b/scripts/ci/mix-lock-backport.sh
@@ -38,19 +38,10 @@ cp "$source_path" "$patched_source"
 check_hash "$patched_source" 532d4926744fcf543f1d0959a81a78d49d4b9ed0ea200541d05f13fcbe56f2e3
 # Elixir prepends its own Mix path during boot, after Erlang processes -pa.
 # Preload the patched module before Elixir starts; subsequent Mix path changes
-# cannot replace an already loaded module. This bootstrap uses only Erlang
-# runtime modules, since Elixir itself has not started yet.
-cat > "$patch_dir/boot.ex" <<'BOOT'
-defmodule Fountain.CI.MixLockBoot do
-  def start do
-    path = :filename.join(:filename.dirname(:code.which(__MODULE__)), ~c"Elixir.Mix.Sync.Lock")
-    {:module, Mix.Sync.Lock} = :code.load_abs(path)
-    :ok
-  end
-end
-BOOT
-elixirc --ignore-module-conflict --warnings-as-errors -o "$patch_dir/ebin" "$patched_source" "$patch_dir/boot.ex"
-export ERL_AFLAGS="${ERL_AFLAGS:+$ERL_AFLAGS }-pa $patch_dir/ebin -s Elixir.Fountain.CI.MixLockBoot"
+# cannot replace an already loaded module. Evaluate the load directly: embedded
+# release boot disables autoloading, so a custom -s bootstrap cannot start there.
+elixirc --ignore-module-conflict --warnings-as-errors -o "$patch_dir/ebin" "$patched_source"
+export ERL_AFLAGS="${ERL_AFLAGS:+$ERL_AFLAGS }-eval '{module,_}=code:load_abs(\"$patch_dir/ebin/Elixir.Mix.Sync.Lock\").'"
 
 # Verify code-path precedence before trusting it for the real command.
 elixir -e '

--- a/scripts/ci/mix-lock-backport.sh
+++ b/scripts/ci/mix-lock-backport.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Backport elixir-lang/elixir#15765 into an isolated code path. Never edit the
+# installed toolchain; ERL_AFLAGS also reaches nested `mix` OS processes.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 --install | command [args...]" >&2
+  exit 2
+fi
+if [[ "$1" == --install && ( $# -ne 1 || -z "${GITHUB_ENV:-}" ) ]]; then
+  echo '--install requires GITHUB_ENV and no other arguments' >&2
+  exit 2
+fi
+
+source_path="$(elixir -e '
+  unless System.version() == "1.19.2", do: raise("retire or re-audit Mix lock backport for this Elixir version")
+  IO.puts(Path.join([:code.lib_dir(:mix), "lib/mix/sync/lock.ex"]))
+')"
+check_hash() {
+  elixir -e '
+    [path, expected] = System.argv()
+    actual = :crypto.hash(:sha256, File.read!(path)) |> Base.encode16(case: :lower)
+    unless actual == expected, do: raise("unexpected Mix lock source fingerprint: #{path}")
+  ' "$1" "$2"
+}
+check_hash "$source_path" 7bd930d9452e83a7f989a41350a261477b9373f39c2146b24571b6a09841f000
+
+# A fixed /tmp prefix has no spaces, so the Erlang flag parser does not need
+# shell-dependent quoting. Each invocation owns a distinct directory.
+patch_dir="$(mktemp -d /tmp/fountain-mix-lock.XXXXXXXX)"
+keep_patch=false
+trap 'if [[ "$keep_patch" == false ]]; then rm -rf "$patch_dir"; fi' EXIT
+mkdir -p "$patch_dir/lib/mix/lib/mix/sync" "$patch_dir/ebin"
+patched_source="$patch_dir/lib/mix/lib/mix/sync/lock.ex"
+cp "$source_path" "$patched_source"
+(cd "$patch_dir" && git apply "$script_dir/mix-lock-15765.patch")
+check_hash "$patched_source" 532d4926744fcf543f1d0959a81a78d49d4b9ed0ea200541d05f13fcbe56f2e3
+# Elixir prepends its own Mix path during boot, after Erlang processes -pa.
+# Preload the patched module before Elixir starts; subsequent Mix path changes
+# cannot replace an already loaded module. This bootstrap uses only Erlang
+# runtime modules, since Elixir itself has not started yet.
+cat > "$patch_dir/boot.ex" <<'BOOT'
+defmodule Fountain.CI.MixLockBoot do
+  def start do
+    path = :filename.join(:filename.dirname(:code.which(__MODULE__)), ~c"Elixir.Mix.Sync.Lock")
+    {:module, Mix.Sync.Lock} = :code.load_abs(path)
+    :ok
+  end
+end
+BOOT
+elixirc --ignore-module-conflict --warnings-as-errors -o "$patch_dir/ebin" "$patched_source" "$patch_dir/boot.ex"
+export ERL_AFLAGS="${ERL_AFLAGS:+$ERL_AFLAGS }-pa $patch_dir/ebin -s Elixir.Fountain.CI.MixLockBoot"
+
+# Verify code-path precedence before trusting it for the real command.
+elixir -e '
+  [expected] = System.argv()
+  Code.ensure_loaded!(Mix.Sync.Lock)
+  actual = :code.which(Mix.Sync.Lock) |> List.to_string() |> Path.dirname()
+  unless actual == expected, do: raise("patched Mix lock was not loaded")
+' "$patch_dir/ebin"
+
+if [[ "$1" == --install ]]; then
+  printf 'ERL_AFLAGS=%s\n' "$ERL_AFLAGS" >> "$GITHUB_ENV"
+  keep_patch=true
+  echo 'Installed pinned Mix lock backport in isolated CI code path'
+else
+  "$@"
+fi


### PR DESCRIPTION
Mix 1.19.2 can wait forever on its own build lock when the OS reuses a listener port. A stale `port_*` file is still hardlinked to a lock file; rewriting it makes the next acquisition probe its own listener. That self-wait can stall CI database setup before tests start.

Backport the exact upstream fix from [elixir-lang/elixir#15765](https://github.com/elixir-lang/elixir/pull/15765), commit `b703302cd1fc91dd1b2df51659daf9b8d6053776`. The wrapper checks Elixir 1.19.2 and source fingerprints, applies the vendored patch to a private temporary copy, and compiles an isolated module. An Erlang `-eval` loads that module before the Elixir CLI adjusts its code path, and also supports embedded release boot. All six pinned core CI jobs export the bootstrap through `ERL_AFLAGS`, so nested Mix VMs use the same fixed lock implementation and namespace.

The installed toolchain is untouched. Locking stays enabled. The wrapper refuses an unreviewed toolchain upgrade; the maintenance notes explain how to retire it when a stable Elixir release includes the fix.

Database setup also emits periodic Mix stack and OS process diagnostics if another stall occurs. The reporter excludes environment variables, messages, dictionary values and command arguments. BEAM snapshots cover the outer VM; nested VMs appear in the OS process listing.

Fixes #1997.

Validation:

- The pinned implementation deterministically waits on its own PID after port reuse; the patched implementation reacquires using real sockets and hardlinks.
- Four regressions pass: normal port reuse, crashed-owner port reuse, inherited cross-VM mutual exclusion, and embedded release boot.
- An independent reviewer verified startup ordering and the patched module origin in ordinary Elixir and embedded Erlang VMs.
- All 57 CI Python tests, ShellCheck and actionlint passed.
- CI installation mode preserved existing `ERL_AFLAGS`; the regression suite passed again with the exported environment.
- Both diagnostic regression tests passed with the patched module, including real contending locks and exclusion of process-dictionary secrets.
- The final branch passed scoped `mix precommit apps/fountain/test/fountain/extension_composition_test.exs`: warnings-as-errors, unused dependencies, formatting, Credo, Dialyzer, Sobelow, production release assembly and 24 tests with zero failures.
- The exact diagnostic `ecto.create` and `ecto.migrate` entry points passed against an isolated database with the backport loaded, including the nested migration Mix VM.
- An actual detached release smoke test passed configuration, HTTP readiness (200), RPC and shutdown with the final loader.

The historical failed runner did not retain its port files or live process tree, so the precise historical cause cannot be proved from that log alone. The regression demonstrates and fixes the upstream self-lock defect on our pinned toolchain.

Combined validation: all seven flake fixes were merged locally with main at `da7b9bd8` on an unpublished integration branch (`11b19a13`). The full umbrella run used the final patched Mix loader at seed `836199` and reported 5,921 Fountain tests and 6 doctests, 144 Buzz tests and 33 Support tests, with 0 failures and 2 existing skips (7 excluded). The earlier 35-file application integration run also passed all 480 tests. No PR was merged for this validation.
