### PR TITLE
test(conversations): await startup and own server teardown

### DIFF
--- a/apps/fountain/test/fountain/conversations/conversation_server_test.exs
+++ b/apps/fountain/test/fountain/conversations/conversation_server_test.exs
@@ -51,6 +51,28 @@ defmodule Fountain.Conversations.ConversationServerTest do
   end
 
   describe "provisioning — happy path" do
+    test "a provision outlasting the system-call timeout is still alive", %{conv: conv} do
+      handle = stub_happy_sprite()
+
+      Mimic.stub(Managoat.Sandbox.Sprites, :create, fn _name, _opts ->
+        # Deliberately cross :sys.get_state/1's five-second timeout. This
+        # reproduces #1702 without relying on scheduler load to delay startup.
+        Process.send_after(self(), :finish_create, 5_100)
+        receive do: (:finish_create -> {:ok, handle})
+      end)
+
+      {pid, _ref, settled} = start_server(conv)
+
+      try do
+        assert settled == :alive
+        assert Conversations._unsafe_get_sandbox!(conv.sandbox_id).status == "ready"
+      after
+        # Also drain the old helper's timed-out, still-provisioning server when
+        # running this regression against the parent commit.
+        GenServer.stop(pid, :normal, :infinity)
+      end
+    end
+
     test "drives the sandbox to ready", %{conv: conv, sandbox: sandbox} do
       stub_happy_sprite()
 
@@ -1182,6 +1204,20 @@ defmodule Fountain.Conversations.ConversationServerTest do
   end
 
   describe "teardown" do
+    test "the harness stops a surviving server before releasing its database owner", %{conv: conv} do
+      stub_happy_sprite()
+      {pid, _ref, :alive} = start_server(conv)
+      key_id = Conversations._unsafe_get_conversation!(conv.id).callback_api_key_id
+      refute Repo.get!(Accounts.ApiKey, key_id).revoked_at
+
+      # ExUnit stops supervised children before on_exit callbacks; DataCase's
+      # separate owner stays alive until its later callback releases the DB.
+      on_exit(fn ->
+        refute Process.alive?(pid)
+        assert Repo.get!(Accounts.ApiKey, key_id).revoked_at
+      end)
+    end
+
     test "revokes the sprite's callback key when the server stops", %{conv: conv} do
       stub_happy_sprite()
 

--- a/apps/fountain/test/support/conversation_server_case.ex
+++ b/apps/fountain/test/support/conversation_server_case.ex
@@ -33,11 +33,8 @@ defmodule Fountain.ConversationServerCase do
       # async ones have finished.
       setup :set_mimic_global
 
-      # The server also needs to reach the sandbox from its own process.
-      setup do
-        Ecto.Adapters.SQL.Sandbox.mode(Fountain.Repo, {:shared, self()})
-        :ok
-      end
+      # DataCase shares the connection through a separate owner that survives
+      # until on_exit. Keep that owner while ExUnit stops supervised servers.
     end
   end
 
@@ -118,8 +115,9 @@ defmodule Fountain.ConversationServerCase do
   @doc """
   Start a real ConversationServer for `conv` and wait for it to settle.
 
-  Started outside Horde and unlinked, so a server that legitimately stops —
-  which the failure paths do — doesn't take the test process with it.
+  Started outside Horde under ExUnit's supervisor, so a server that legitimately
+  stops doesn't take the test process with it. ExUnit stops any surviving server
+  before DataCase releases the SQL Sandbox owner, including on a failed test.
   """
   def start_server(conv, opts \\ []) do
     runtime = Keyword.get(opts, :runtime, Managoat.Runtimes.Testing.FakeRuntime)
@@ -131,7 +129,13 @@ defmodule Fountain.ConversationServerCase do
       runtime_module: runtime
     ]
 
-    {:ok, pid} = GenServer.start(Fountain.Conversations.ConversationServer, args)
+    pid =
+      ExUnit.Callbacks.start_supervised!(%{
+        id: make_ref(),
+        start: {GenServer, :start_link, [Fountain.Conversations.ConversationServer, args]},
+        restart: :temporary
+      })
+
     ref = Process.monitor(pid)
 
     # The prompt is delivered out of band, exactly as production does it: it is
@@ -153,10 +157,12 @@ defmodule Fountain.ConversationServerCase do
     end
 
     # handle_continue(:provision) runs before any call is answered, so a
-    # synchronous call is enough to know provisioning has finished.
+    # synchronous call is enough to know provisioning has finished. Let ExUnit's
+    # test timeout bound a hung provision: the default five-second system-call
+    # timeout mislabeled a slow, live server as :stopped (#1702).
     settled =
       try do
-        _ = :sys.get_state(pid)
+        _ = :sys.get_state(pid, :infinity)
         :alive
       catch
         :exit, _ -> :stopped


### PR DESCRIPTION
`ConversationServerCase.start_server/2` treated the five-second timeout from `:sys.get_state/1` as a stopped server even when provisioning was still running. The resulting assertion failure could release SQL ownership underneath that server. Wait for provisioning to settle under ExUnit's existing test timeout, and give ExUnit ownership of temporary server children so teardown finishes before the database owner is released. Keep DataCase's separate shared owner instead of replacing it with the test process.

A regression holds sprite creation past five seconds and reproduces `left: :stopped, right: :alive` on the unchanged helper. Another leaves a server running at test completion and checks that teardown stops it and revokes its callback key while the SQL owner still exists. Existing stopped-server behavior remains covered by the provisioning failure tests.

Fixes #1702. Recovered the original local evidence: seed `836199`, `ConversationServerTest`'s “a live server stops without destroying the sprite; the rows say so” (then line 1224), actual `start_server` result `:stopped`, followed by SQL ownership errors in the still-running provision. The original captured exit reason was missing; the new controlled regression establishes this harness race directly.

Validation:
- The delayed-provision regression fails on the unchanged helper (`:stopped` instead of `:alive`) and passes with the fix at seeds 0, 121815 and 836199.
- `ConversationServerTest`: 60 tests, 0 failures at recovered seed 836199, including teardown ownership.
- `mix precommit` with all 25 files using `ConversationServerCase`, seed 836199: 353 tests, 0 failures; compile, format, Credo, Dialyzer, Sobelow and production release assembly passed. Dedicated database and independent builds. Full-suite CI will run on this PR.

Combined validation: all seven flake fixes were merged locally with main at `da7b9bd8` on an unpublished integration branch (`11b19a13`). The full umbrella run used the final patched Mix loader at seed `836199` and reported 5,921 Fountain tests and 6 doctests, 144 Buzz tests and 33 Support tests, with 0 failures and 2 existing skips (7 excluded). The earlier 35-file application integration run also passed all 480 tests. No PR was merged for this validation.
