### PR TITLE
Fix docs test timeouts from bcrypt scheduler contention

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,10 @@
 import Config
 
+# Fixture password hashes share the dirty CPU schedulers with MDEx and Lumis.
+# Production-cost hashes can starve the docs guardrails past their timeout
+# (#1701). Keep real hashing and verification at bcrypt's recommended test cost.
+config :bcrypt_elixir, :log_rounds, 4
+
 config :fountain, Fountain.Repo,
   url:
     System.get_env("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/fountain_test"),


### PR DESCRIPTION
The docs heading guardrail shares BEAM dirty CPU schedulers with bcrypt password hashing. Fixture users were paying bcrypt's default cost of 12, allowing sustained async fixture creation to keep the 111-page rendering check behind queued native work past its 60-second ExUnit limit. Set bcrypt's documented test-only cost of 4 in `config/test.exs`; password hashing and verification still run normally.

Fixes #1701.

Controlled reproduction on OTP 28.3 / Elixir 1.19.2 with `ERL_FLAGS='+S 4:4'`:

| Workload alongside the exact heading guardrail | Cost 12 | Cost 4 |
| --- | ---: | ---: |
| 8 workers × 125 password hashes | 57,808 ms | 1,012 ms |
| 8 workers × 150 password hashes | 68,338 ms | 656 ms |

The second default-cost run exceeded 60 seconds. Its sampled stack was in `Lumis.highlight/2` through `Managoat.Docs.Checks.rendered_pages/1`; the dirty CPU queue contained 5 jobs while all four normal run queues were empty. The original report sampled `MDExNative.Comrak.parse_document/2`, which uses the same dirty CPU queue. This reproduces cumulative native-work contention; it does not establish that the uninstrumented original run stopped on one particular page or downloaded a parser.

The unchanged `bcrypt_elixir` dependency explicitly recommends cost 4 for tests. Reading the complete configuration independently confirms test cost 4 and production's unchanged default cost 12. No password-cost override or cost-specific production-security assertion existed in the suite.

Validation: scoped `mix precommit` passed compile, formatting, Credo, Dialyzer, Sobelow, production release assembly, and 125 tests covering docs rendering, registration, authentication, OAuth-only accounts, and password reset. The same 125 tests then passed 11 consecutive runs with `--seed 0 --repeat-until-failure 10` (1,375 tests, 0 failures), using an isolated PostgreSQL database.

Combined validation: all seven flake fixes were merged locally with main at `da7b9bd8` on an unpublished integration branch (`11b19a13`). The full umbrella run used the final patched Mix loader at seed `836199` and reported 5,921 Fountain tests and 6 doctests, 144 Buzz tests and 33 Support tests, with 0 failures and 2 existing skips (7 excluded). The earlier 35-file application integration run also passed all 480 tests. No PR was merged for this validation.
