### PR TITLE
Remove deprecated BILLING_ENABLED fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -284,7 +284,6 @@ SLACK_OAUTH_CLIENT_SECRET=
 # packs sold through Stripe Checkout, a 402 at zero. That is meaningful for
 # the hosted instance and a lock with no key on a self-hosted one.
 # CREDITS_ENABLED=true
-# (BILLING_ENABLED is the old name and still read, with a warning, for one release.)
 
 # Stripe billing (only with CREDITS_ENABLED=true)
 STRIPE_SECRET_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ upgrade, is in
 
 ### Upgrade notes
 
+- `BILLING_ENABLED` is no longer supported. Set `CREDITS_ENABLED=true` to
+  enable credits. With only the old variable set, credits remain off by default.
+  The hosted home-cloud deployment already uses `CREDITS_ENABLED`.
+
 - **Connections needs no `FEATURE_FLAGS_ON` entry on a deployment without
   PostHog** (#1693). Gating Connections behind the `connections` flag (#1620)
   took the feature away from every deployment that configures no flag service,

--- a/apps/fountain/test/fountain/self_host_switches_test.exs
+++ b/apps/fountain/test/fountain/self_host_switches_test.exs
@@ -96,14 +96,23 @@ defmodule Fountain.SelfHostSwitchesTest do
       assert cfg[:fountain][:credits_enabled] == true
     end
 
-    test "BILLING_ENABLED is read as an alias for one release, and CREDITS_ENABLED wins (#1144)" do
-      legacy =
-        read_prod_config(%{"BILLING_ENABLED" => "true", "STRIPE_WEBHOOK_SECRET" => "whsec_test"})
+    test "BILLING_ENABLED no longer enables credits" do
+      cfg = read_prod_config(%{"BILLING_ENABLED" => "true"})
+      assert cfg[:fountain][:credits_enabled] == false
+    end
 
-      assert legacy[:fountain][:credits_enabled] == true
+    test "CREDITS_ENABLED controls credits when the retired variable is also set" do
+      disabled = read_prod_config(%{"CREDITS_ENABLED" => "false", "BILLING_ENABLED" => "true"})
+      assert disabled[:fountain][:credits_enabled] == false
 
-      both = read_prod_config(%{"CREDITS_ENABLED" => "false", "BILLING_ENABLED" => "true"})
-      assert both[:fountain][:credits_enabled] == false
+      enabled =
+        read_prod_config(%{
+          "CREDITS_ENABLED" => "true",
+          "BILLING_ENABLED" => "false",
+          "STRIPE_WEBHOOK_SECRET" => "whsec_test"
+        })
+
+      assert enabled[:fountain][:credits_enabled] == true
     end
 
     test "REGISTRATION_ALLOWED_EMAIL_DOMAINS is split, trimmed and downcased" do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -516,29 +516,10 @@ config :sentry,
 # themselves out of their own instance. The hosted deployment is the one that
 # opts in (its overlay sets CREDITS_ENABLED=true explicitly).
 #
-# BILLING_ENABLED was the name until #1144; it is read as an alias for one
-# release, with a warning, so a deployment can flip at its own pace.
-#
 # Skipped in :test — the suite pins the gate on in config/test.exs and
 # toggles it per-test through the application env, independent of whatever
 # CREDITS_ENABLED happens to be in the developer's shell or .env.
-credits_enabled? =
-  case {System.get_env("CREDITS_ENABLED"), System.get_env("BILLING_ENABLED")} do
-    {nil, nil} ->
-      false
-
-    {nil, legacy} ->
-      IO.puts(:stderr, """
-
-      WARNING: BILLING_ENABLED is deprecated; set CREDITS_ENABLED=#{legacy} instead.
-      The alias will be removed in a later release.
-      """)
-
-      legacy != "false"
-
-    {value, _} ->
-      value != "false"
-  end
+credits_enabled? = System.get_env("CREDITS_ENABLED", "false") != "false"
 
 if config_env() != :test do
   config :fountain, :credits_enabled, credits_enabled?

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,6 @@ at a dead end, with no error to see. Read [Email](guides/operate/email.md).
 | Variable | Default | Required | Effect |
 |---|---|---|---|
 | `CREDITS_ENABLED` | `false` | — | Credits on. Off by default: on a self-hosted instance there is nothing to sell. On, every account holds a credit balance, turns and contacts burn it, and a zero balance refuses new work. |
-| `BILLING_ENABLED` | — | — | The old name of `CREDITS_ENABLED`. Fountain reads it for one release and writes a warning at boot. `CREDITS_ENABLED` wins when you set both. |
 | `STRIPE_SECRET_KEY` | — | For billing. | The Stripe API key. |
 | `STRIPE_WEBHOOK_SECRET` | — | For billing. | Verifies the signature on a `POST /api/stripe/webhook`. |
 | `PROVIDER_HOURLY_CENTS` | — | No. | What you pay each sandbox provider, in cents per sandbox hour, as `sprites=10.76,e2b=5.45`. Rates can be fractional. A provider you leave out stays unpriced. |


### PR DESCRIPTION
Remove the deprecated `BILLING_ENABLED` environment-variable fallback and its boot warning. `CREDITS_ENABLED` is now the sole control, with the existing default of `false`. A deployment setting only `BILLING_ENABLED=true` will leave credits disabled; home-cloud, the known consumer, already sets `CREDITS_ENABLED=true` in its deployment patch and generated manifests.

Update the configuration reference and environment example, add an upgrade note, and replace the alias test with regressions for the retired variable alone and conflicting values for both variables.

Validation:
- Configuration and documentation tests: 52 tests, 0 failures.
- Compilation with warnings as errors, formatting, unused-dependency check, and strict Credo passed.
- `git diff --check` and Destink passed. Advisory docs-style/Vale reports have existing findings outside this change.
- Full `mix precommit` is still running locally (Dialyzer cache rebuild); CI will run the full gates.
