### PR TITLE
chore(sdk): drop legacy stdout paragraph assembly

### DIFF
--- a/sdk/swift/CHANGELOG.md
+++ b/sdk/swift/CHANGELOG.md
@@ -7,6 +7,8 @@ Notable changes to the Fountain Swift SDK follow
 
 ### Changed
 
+- Both Swift clients assemble text as ACP chunks. Removed the legacy stdout row paragraph separators; text after a tool call still starts a new paragraph.
+
 - `Agent.model` is `String?`. The `acp` runtime resolves no inference
   credential and reads no model, so the wire sends an explicit null there. A
   non-optional `model` threw `valueNotFound` on decode, and because a page is

--- a/sdk/swift/Sources/Fountain/RunTypes.swift
+++ b/sdk/swift/Sources/Fountain/RunTypes.swift
@@ -98,21 +98,20 @@ final class TurnFollower {
     let eventTurnID = event["turn_id"]?.stringValue
     if let turnID, let eventTurnID, eventTurnID != turnID { return [] }
     if !started && turnID == nil { return [] }
-    let acp = event["stream"]?.stringValue == "acp"
     var output: [RunEvent] = []
     for block in event["blocks"]?.arrayValue?.compactMap(\.objectValue) ?? [] {
       output.append(.block(block: block, event: event))
-      output.append(contentsOf: applyBlock(block, acp: acp))
+      output.append(contentsOf: applyBlock(block))
     }
     return output
   }
 
-  private func applyBlock(_ block: JSONObject, acp: Bool) -> [RunEvent] {
+  private func applyBlock(_ block: JSONObject) -> [RunEvent] {
     let body = block["body"]?.stringValue ?? ""
     switch block["kind"]?.stringValue {
     case "text":
       guard !body.isEmpty else { return [] }
-      let prefix = paragraphBreak(acp: acp)
+      let prefix = paragraphBreak()
       chunks.append(prefix + body)
       breakBeforeText = false
       return [.text(prefix + body)]
@@ -144,9 +143,9 @@ final class TurnFollower {
     }
   }
 
-  private func paragraphBreak(acp: Bool) -> String {
+  private func paragraphBreak() -> String {
     guard !chunks.isEmpty else { return "" }
-    if acp && !breakBeforeText { return "" }
+    if !breakBeforeText { return "" }
     return chunks.last?.hasSuffix("\n") == true ? "" : "\n\n"
   }
 }

--- a/sdk/swift/Sources/FountainKit/SSE/TurnFollower.swift
+++ b/sdk/swift/Sources/FountainKit/SSE/TurnFollower.swift
@@ -96,20 +96,19 @@ public struct TurnFollower: Sendable {
     // Tail of an older turn arriving before ours starts.
     if !started && turnID == nil { return [] }
 
-    let acp = event.stream == .acp
     var events: [TurnEvent] = []
     for block in event.blocks ?? [] {
       events.append(.block(block, event: event))
-      events.append(contentsOf: apply(block: block, acp: acp))
+      events.append(contentsOf: apply(block: block))
     }
     return events
   }
 
-  private mutating func apply(block: Block, acp: Bool) -> [TurnEvent] {
+  private mutating func apply(block: Block) -> [TurnEvent] {
     switch block.kind {
     case .text:
       guard let body = block.body, !body.isEmpty else { return [] }
-      let prefix = paragraphBreak(acp: acp)
+      let prefix = paragraphBreak()
       chunks.append(prefix + body)
       breakBeforeText = false
       return [.text(prefix + body)]
@@ -146,12 +145,11 @@ public struct TurnFollower: Sendable {
     }
   }
 
-  /// ACP chunks are pieces of one message and join with nothing; legacy
-  /// stdout rows are whole messages and join as paragraphs; text after a
-  /// tool call always starts a new paragraph.
-  private func paragraphBreak(acp: Bool) -> String {
+  /// ACP chunks are pieces of one message and join with nothing; text after
+  /// a tool call starts a new paragraph.
+  private func paragraphBreak() -> String {
     guard let last = chunks.last else { return "" }
-    if acp && !breakBeforeText { return "" }
+    if !breakBeforeText { return "" }
     return last.hasSuffix("\n") ? "" : "\n\n"
   }
 }

--- a/sdk/swift/Tests/FountainKitTests/TurnFollowerTests.swift
+++ b/sdk/swift/Tests/FountainKitTests/TurnFollowerTests.swift
@@ -51,18 +51,19 @@ import Testing
     }
   }
 
-  @Test func acpChunksConcatenateStdoutParagraphs() {
+  @Test(arguments: ["acp", "stdout"])
+  func outputRowsJoinWithoutStreamSpecificSeparators(stream: String) {
     var follower = TurnFollower(turnNumber: 1)
     _ = follower.apply(stage("started"))
-    _ = follower.apply(output(#"{"kind":"text","body":"Hel"}"#))
-    _ = follower.apply(output(#"{"kind":"text","body":"lo"}"#))
+    let events =
+      follower.apply(output(#"{"kind":"text","body":"Hel"}"#, stream: stream))
+      + follower.apply(output(#"{"kind":"text","body":"lo"}"#, stream: stream))
+    let text = events.compactMap { event -> String? in
+      if case .text(let chunk) = event { return chunk }
+      return nil
+    }
+    #expect(text == ["Hel", "lo"])
     #expect(follower.text == "Hello")
-
-    var legacy = TurnFollower(turnNumber: 1)
-    _ = legacy.apply(stage("started"))
-    _ = legacy.apply(output(#"{"kind":"text","body":"one"}"#, stream: "stdout"))
-    _ = legacy.apply(output(#"{"kind":"text","body":"two"}"#, stream: "stdout"))
-    #expect(legacy.text == "one\n\ntwo")
   }
 
   @Test func textAfterToolStartsNewParagraph() {

--- a/sdk/swift/Tests/FountainTests/CoreTests.swift
+++ b/sdk/swift/Tests/FountainTests/CoreTests.swift
@@ -63,6 +63,23 @@ import Testing
     })
 }
 
+@Test(arguments: ["acp", "stdout"])
+func outputRowsJoinWithoutStreamSpecificSeparators(stream: String) {
+  let follower = TurnFollower(turnNumber: 1, turnID: "t1")
+  let events = ["Hel", "lo"].flatMap { body in
+    follower.apply([
+      "kind": "output", "stream": .string(stream), "turn_id": "t1",
+      "blocks": [["kind": "text", "body": .string(body)]],
+    ])
+  }
+  let text = events.compactMap { event -> String? in
+    if case .text(let chunk) = event { return chunk }
+    return nil
+  }
+  #expect(text == ["Hel", "lo"])
+  #expect(follower.text == "Hello")
+}
+
 @Test func anUnparseableBaseURLThrowsAndNamesWhereItCameFrom() throws {
   // A base URL without a scheme used to fall back to the hosted Fountain, which
   // put the caller's API key on a host they never named.

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -11,6 +11,12 @@ server releases.
 
 ---
 
+## [1.32.0] - 2026-09-13
+
+### Removed
+
+- Legacy stdout row paragraph separators when assembling run text. Text now joins as ACP chunks on every stream, with paragraph breaks after tool calls preserved. Historical stdout rows no longer receive automatic blank lines.
+
 ## [1.31.1] - 2026-09-13
 
 ### Fixed

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -73,7 +73,7 @@ CONV=$(curl -sH "$AUTH" -H 'Content-Type: application/json' \
 #    - page /events?blocks=true&after=N until has_more is false
 #    - keep only events whose turn_id is *your* turn's
 #    - keep only `text` blocks; `tool_use` is not the answer, `thinking` is not either
-#    - join acp chunks with nothing, stdout rows with a blank line,
+#    - join ACP chunks without an added separator,
 #      and start a new paragraph after any tool call
 #    - stop on stage/turn/done — or failed, or interrupted
 #    - and when the connection drops mid-turn, resume from the last event id

--- a/sdk/typescript/examples/chat.ts
+++ b/sdk/typescript/examples/chat.ts
@@ -148,7 +148,7 @@ try {
   const conversation = fountain.resume(conversationId);
   const [turns, events] = await Promise.all([
     conversation.turns(),
-    conversation.history({ streams: ["acp", "stdout"] }),
+    conversation.history({ streams: ["acp"] }),
   ]);
   await conversation.markRead();
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@managoat/fountain-sdk",
-  "version": "1.31.1",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@managoat/fountain-sdk",
-      "version": "1.31.1",
+      "version": "1.32.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^26.4.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@managoat/fountain-sdk",
-  "version": "1.31.1",
+  "version": "1.32.0",
   "description": "Run a coding agent on a real computer, with your repos and your credentials, in one call.",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -19,7 +19,7 @@ export interface RequestOptions {
  * this string is already what Fountain's request logs are keyed on. The
  * version half is asserted against `package.json` by a test.
  */
-export const USER_AGENT = "fountain-sdk-js/1.31.1";
+export const USER_AGENT = "fountain-sdk-js/1.32.0";
 
 /**
  * The thin layer everything else is built on: one bearer token, JSON in and

--- a/sdk/typescript/src/turn.ts
+++ b/sdk/typescript/src/turn.ts
@@ -16,10 +16,7 @@ const TERMINAL_TURN_STATES = new Set(["done", "failed", "interrupted"]);
  *   - text that follows a tool call is a new message, so it gets a paragraph
  *     break — the rule that stops a transcript reading as one run-on sentence.
  *
- * The joining rules are ported from the Hermes plugin, which learned them
- * against real runtimes: ACP streams one message as chunks that join with
- * nothing, while a legacy stdout row is a whole message and joins as a
- * paragraph.
+ * ACP streams one message as chunks that join without an added separator.
  */
 export class TurnFollower {
   readonly turnNumber: number;
@@ -94,22 +91,21 @@ export class TurnFollower {
     // Output from before our turn opened is the tail of an older one.
     if (!this.started && !this.turnId) return [];
 
-    const acp = event.stream === "acp";
     const out: RunEvent[] = [];
 
     for (const block of event.blocks ?? []) {
       out.push({ type: "block", block, event });
-      out.push(...this.applyBlock(block, acp));
+      out.push(...this.applyBlock(block));
     }
     return out;
   }
 
-  private applyBlock(block: Block, acp: boolean): RunEvent[] {
+  private applyBlock(block: Block): RunEvent[] {
     const body = block.body ?? "";
 
     if (block.kind === "text") {
       if (!body) return [];
-      const prefix = this.paragraphBreak(acp);
+      const prefix = this.paragraphBreak();
       if (prefix) this.chunks.push(prefix);
       this.chunks.push(body);
       this.breakBeforeText = false;
@@ -157,11 +153,11 @@ export class TurnFollower {
 
   /**
    * ACP chunks are pieces of one message and join with nothing; anything after
-   * a tool call is a new message. A legacy row is a whole message either way.
+   * a tool call is a new message.
    */
-  private paragraphBreak(acp: boolean): string {
+  private paragraphBreak(): string {
     if (!this.chunks.length) return "";
-    if (acp && !this.breakBeforeText) return "";
+    if (!this.breakBeforeText) return "";
     const last = this.chunks[this.chunks.length - 1] ?? "";
     return last.endsWith("\n") ? "" : "\n\n";
   }

--- a/sdk/typescript/test/run.test.ts
+++ b/sdk/typescript/test/run.test.ts
@@ -145,17 +145,20 @@ describe("run", () => {
     assert.equal(run.text, "mine");
   });
 
-  test("a stdout runtime joins rows as paragraphs, acp joins chunks", async () => {
+  test("output rows join as chunks without stream-specific separators", async () => {
     fake.onTurn = (conversation, turnNumber) => {
       fake.scriptTurn(conversation.id, {
         turnNumber,
         turnId: "t1",
-        text: ["first line", "second line"],
+        text: ["first ", "line"],
         stream: "stdout",
       });
     };
-    const legacy = await client().run("go", { agent: "reposage" });
-    assert.equal(legacy.text, "first line\n\nsecond line");
+    const run = client().run("go", { agent: "reposage" });
+    const chunks: string[] = [];
+    for await (const chunk of run.textStream) chunks.push(chunk);
+    assert.deepEqual(chunks, ["first ", "line"]);
+    assert.equal((await run).text, "first line");
   });
 
   test("text after a tool call starts a new paragraph", async () => {


### PR DESCRIPTION
The TypeScript SDK and both Swift clients still treated non-ACP output rows as complete messages, inserting blank lines between them. With runtimes now ACP-only, remove the stream-dependent paragraph assembly and join text chunks without an added separator. Paragraph breaks after tool calls remain intact.

Update the regression tests to check streamed chunks and accumulated text, remove stdout from the chat example's history filter, and refresh the documentation and changelogs. The TypeScript release is bumped to 1.32.0 with its lockfile and user agent in sync. Historical stdout rows no longer receive automatic blank lines.

Validation:
- TypeScript: typecheck, all 111 tests (including conformance), build, and contract verification passed.
- Swift: strict formatting, 87 tests (including both clients' conformance suites), and release build passed with warnings treated as errors; existing opt-in/placeholder tests remain skipped.
- SDK release guard and publish-tag regression tests passed.
