### PR TITLE
refactor(console): replace and remove legacy component helpers

### DIFF
--- a/apps/fountain/lib/fountain_web/components/core_components.ex
+++ b/apps/fountain/lib/fountain_web/components/core_components.ex
@@ -77,86 +77,6 @@ defmodule FountainWeb.CoreComponents do
     do:
       "bg-transparent text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-2)] hover:text-[var(--color-text-primary)]"
 
-  # ── Legacy aliases (kept for backward-compat) ─────────────────────────────
-
-  attr :type, :string, default: "button"
-  attr :class, :string, default: ""
-
-  attr :rest, :global,
-    include: ~w(disabled form name value phx-click phx-disable-with phx-value-id data-confirm)
-
-  slot :inner_block, required: true
-
-  def btn(assigns) do
-    ~H"""
-    <button
-      type={@type}
-      class={[
-        "inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-        "bg-[var(--color-brand)] text-[var(--color-brand-text)] hover:bg-[var(--color-brand-hover)]",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]",
-        "disabled:opacity-50",
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </button>
-    """
-  end
-
-  attr :type, :string, default: "button"
-  attr :class, :string, default: ""
-
-  attr :rest, :global,
-    include: ~w(disabled form name value phx-click phx-disable-with phx-value-id data-confirm)
-
-  slot :inner_block, required: true
-
-  def btn_secondary(assigns) do
-    ~H"""
-    <button
-      type={@type}
-      class={[
-        "inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-        "bg-[var(--color-bg-2)] text-[var(--color-text-primary)] hover:bg-[var(--color-bg-3)]",
-        "border border-[var(--color-border)]",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]",
-        "disabled:opacity-50",
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </button>
-    """
-  end
-
-  attr :class, :string, default: ""
-
-  attr :rest, :global,
-    include: ~w(disabled form name value phx-click phx-disable-with phx-value-id data-confirm)
-
-  slot :inner_block, required: true
-
-  def btn_danger(assigns) do
-    ~H"""
-    <button
-      type="button"
-      class={[
-        "inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-        "bg-[var(--color-error)] text-white hover:opacity-90",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]",
-        "disabled:opacity-50",
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </button>
-    """
-  end
-
   # ────────────────────────────────────────────────────────────────────────────
   # badge/1
   # Renders both status vocabularies (#401 — the old comment labelled the
@@ -213,10 +133,6 @@ defmodule FountainWeb.CoreComponents do
   defp badge_dot_class("terminated"), do: "bg-[var(--status-terminated-text)]"
   defp badge_dot_class("failed"), do: "bg-[var(--status-failed-text)]"
   defp badge_dot_class(_), do: "bg-[var(--color-text-muted)]"
-
-  # Legacy alias
-  attr :status, :string, required: true
-  def status_badge(assigns), do: badge(assigns)
 
   # ────────────────────────────────────────────────────────────────────────────
   # label_chips/1 (#1637)
@@ -577,7 +493,7 @@ defmodule FountainWeb.CoreComponents do
   attr :class, :string, default: ""
 
   attr :rest, :global,
-    include: ~w(autofocus required disabled readonly rows cols min max step pattern phx-hook)
+    include: ~w(autofocus required disabled readonly rows cols min max step pattern phx-hook list)
 
   def form_field(assigns) do
     ~H"""
@@ -625,50 +541,6 @@ defmodule FountainWeb.CoreComponents do
       <p :for={error <- @errors} class="text-xs text-[var(--color-error)]" role="alert">
         {error}
       </p>
-    </div>
-    """
-  end
-
-  # ── Legacy input alias ───────────────────────────────────────────────────────
-
-  attr :id, :string, required: true
-  attr :name, :string, required: true
-  attr :label, :string, default: nil
-  attr :type, :string, default: "text"
-  attr :value, :string, default: ""
-  attr :placeholder, :string, default: nil
-  # `list` is an <input>-specific attribute, not one of Phoenix's HTML globals,
-  # so it has to be opted in for a datalist to attach.
-  attr :rest, :global, include: ~w(autofocus required disabled rows pattern phx-hook list)
-
-  def input(assigns) do
-    ~H"""
-    <div class="space-y-1">
-      <label
-        :if={@label}
-        for={@id}
-        class="block text-sm font-medium text-[var(--color-text-primary)]"
-      >
-        {@label}
-      </label>
-      <input
-        :if={@type != "textarea"}
-        type={@type}
-        name={@name}
-        id={@id}
-        value={@value}
-        placeholder={@placeholder}
-        class="block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)]"
-        {@rest}
-      />
-      <textarea
-        :if={@type == "textarea"}
-        name={@name}
-        id={@id}
-        placeholder={@placeholder}
-        class="block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-1)] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-focus-ring)]"
-        {@rest}
-      >{@value}</textarea>
     </div>
     """
   end

--- a/apps/fountain/lib/fountain_web/live/agents_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/form.ex
@@ -741,17 +741,24 @@ defmodule FountainWeb.AgentsLive.Form do
         phx-submit="submit"
         class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200"
       >
-        <.input id="name" name="agent[name]" label="Name" value={@form["name"]} autofocus required />
+        <.form_field
+          id="name"
+          name="agent[name]"
+          label="Name"
+          value={@form["name"]}
+          autofocus
+          required
+        />
         <.error_msg field="name" errors={@errors} />
 
-        <.input
+        <.form_field
           id="description"
           name="agent[description]"
           label="Description"
           value={@form["description"]}
         />
 
-        <.input
+        <.form_field
           id="system"
           name="agent[system]"
           type="textarea"
@@ -773,7 +780,7 @@ defmodule FountainWeb.AgentsLive.Form do
               </option>
             </select>
           </div>
-          <.input
+          <.form_field
             id="model"
             name="agent[model]"
             label="Model"
@@ -789,7 +796,7 @@ defmodule FountainWeb.AgentsLive.Form do
         </div>
         <.error_msg field="model" errors={@errors} />
         <div :if={command_runtime?(@form["runtime"])} class="space-y-1">
-          <.input
+          <.form_field
             id="runtime_command"
             name="agent[runtime_command]"
             label="Command"
@@ -1170,14 +1177,14 @@ defmodule FountainWeb.AgentsLive.Form do
             <input type="hidden" name={"agent[skills][#{i}][type]"} value={skill["type"]} />
 
             <div :if={skill["type"] == "github"} class="grid grid-cols-2 gap-2">
-              <.input
+              <.form_field
                 id={"skill_#{i}_source"}
                 name={"agent[skills][#{i}][source]"}
                 label="Source (owner/repo)"
                 value={skill["source"] || ""}
                 placeholder="anthropics/skills"
               />
-              <.input
+              <.form_field
                 id={"skill_#{i}_name"}
                 name={"agent[skills][#{i}][name]"}
                 label="Name (optional)"
@@ -1187,14 +1194,14 @@ defmodule FountainWeb.AgentsLive.Form do
             </div>
 
             <div :if={skill["type"] == "inline"} class="space-y-2">
-              <.input
+              <.form_field
                 id={"skill_#{i}_inline_name"}
                 name={"agent[skills][#{i}][name]"}
                 label="Name"
                 value={skill["name"] || ""}
                 placeholder="my-skill"
               />
-              <.input
+              <.form_field
                 id={"skill_#{i}_content"}
                 name={"agent[skills][#{i}][content]"}
                 type="textarea"
@@ -1261,7 +1268,7 @@ defmodule FountainWeb.AgentsLive.Form do
               </button>
             </div>
 
-            <.input
+            <.form_field
               id={"mcp_#{i}_name"}
               name={"agent[mcp_servers][#{i}][name]"}
               label="Server name"
@@ -1313,7 +1320,7 @@ defmodule FountainWeb.AgentsLive.Form do
                 </option>
               </select>
             </div>
-            <.input
+            <.form_field
               :if={server["kind"] == "connection"}
               id={"mcp_#{i}_url"}
               name={"agent[mcp_servers][#{i}][url]"}
@@ -1333,7 +1340,7 @@ defmodule FountainWeb.AgentsLive.Form do
               <code class="font-mono">{Jason.encode!(server["raw"])}</code>
             </div>
 
-            <.input
+            <.form_field
               :if={server["kind"] in [nil, "stdio"]}
               id={"mcp_#{i}_command"}
               name={"agent[mcp_servers][#{i}][command]"}
@@ -1341,7 +1348,7 @@ defmodule FountainWeb.AgentsLive.Form do
               value={server["command"] || ""}
               placeholder="npx"
             />
-            <.input
+            <.form_field
               :if={server["kind"] in [nil, "stdio"]}
               id={"mcp_#{i}_args"}
               name={"agent[mcp_servers][#{i}][args]"}
@@ -1409,9 +1416,9 @@ defmodule FountainWeb.AgentsLive.Form do
         </div>
 
         <div class="flex gap-2">
-          <.btn type="submit" phx-disable-with="Saving\u2026">Save</.btn>
+          <.button type="submit" phx-disable-with="Saving\u2026">Save</.button>
           <.link navigate={~p"/agents"}>
-            <.btn_secondary>Cancel</.btn_secondary>
+            <.button variant="secondary">Cancel</.button>
           </.link>
         </div>
       </form>

--- a/apps/fountain/lib/fountain_web/live/agents_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/index.ex
@@ -220,7 +220,7 @@ defmodule FountainWeb.AgentsLive.Index do
         <div class="flex items-center justify-between">
           <h1 class="text-2xl font-semibold">Agents</h1>
           <.link href={~p"/agents/new"}>
-            <.btn>+ New agent</.btn>
+            <.button>+ New agent</.button>
           </.link>
         </div>
 
@@ -334,7 +334,7 @@ defmodule FountainWeb.AgentsLive.Index do
               <td class="px-4 py-3 text-right">
                 <div class="inline-flex gap-1">
                   <.link href={~p"/agents/#{a.id}/edit"}>
-                    <.btn_secondary>Edit</.btn_secondary>
+                    <.button variant="secondary">Edit</.button>
                   </.link>
                   <button
                     class="px-2 py-1 rounded text-xs cursor-pointer bg-[var(--color-error-bg)] border border-[var(--color-error)] text-[var(--color-error-text)] hover:bg-[var(--color-error)] hover:text-white transition-colors"

--- a/apps/fountain/lib/fountain_web/live/agents_live/versions.ex
+++ b/apps/fountain/lib/fountain_web/live/agents_live/versions.ex
@@ -98,7 +98,7 @@ defmodule FountainWeb.AgentsLive.Versions do
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">History — {@agent.name}</h1>
         <.link navigate={~p"/agents/#{@agent.id}/edit"}>
-          <.btn_secondary>Back to agent</.btn_secondary>
+          <.button variant="secondary">Back to agent</.button>
         </.link>
       </div>
 
@@ -122,14 +122,15 @@ defmodule FountainWeb.AgentsLive.Versions do
               {Calendar.strftime(version.inserted_at, "%Y-%m-%d %H:%M UTC")}
             </span>
           </div>
-          <.btn_secondary
+          <.button
             :if={not current?(@versions, version.version)}
+            variant="secondary"
             phx-click="rollback"
             phx-value-version={version.version}
             data-confirm={"Apply version #{version.version}'s config as a new edit?"}
           >
             Roll back to this
-          </.btn_secondary>
+          </.button>
         </div>
 
         <div :if={previous == nil} class="text-sm text-zinc-500">

--- a/apps/fountain/lib/fountain_web/live/connections_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/connections_live/index.ex
@@ -621,65 +621,65 @@ defmodule FountainWeb.ConnectionsLive.Index do
           </ul>
           <input type="hidden" name="provider[kind]" value={@provider_form["kind"]} />
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <.input
+            <.form_field
               name="provider[name]"
               label="Name"
               value={@provider_form["name"]}
               id="provider_name"
             />
-            <.input
+            <.form_field
               name="provider[slug]"
               label="Slug"
               value={@provider_form["slug"]}
               id="provider_slug"
               placeholder="github"
             />
-            <.input
+            <.form_field
               :if={@provider_form["kind"] == "oauth2"}
               name="provider[authorize_url]"
               label="Authorize URL"
               value={@provider_form["authorize_url"]}
               id="provider_authorize_url"
             />
-            <.input
+            <.form_field
               :if={@provider_form["kind"] == "oauth2"}
               name="provider[token_url]"
               label="Token URL"
               value={@provider_form["token_url"]}
               id="provider_token_url"
             />
-            <.input
+            <.form_field
               name="provider[revoke_url]"
               label="Revoke URL (optional)"
               value={@provider_form["revoke_url"]}
               id="provider_revoke_url"
             />
-            <.input
+            <.form_field
               name="provider[userinfo_url]"
               label="Userinfo URL (optional)"
               value={@provider_form["userinfo_url"]}
               id="provider_userinfo_url"
             />
-            <.input
+            <.form_field
               name="provider[account_label_path]"
               label="Account name path in userinfo"
               value={@provider_form["account_label_path"]}
               id="provider_account_label_path"
               placeholder="email"
             />
-            <.input
+            <.form_field
               name="provider[scopes]"
               label="Scopes (space-separated)"
               value={@provider_form["scopes"]}
               id="provider_scopes"
             />
-            <.input
+            <.form_field
               name="provider[client_id]"
               label="Client id"
               value={@provider_form["client_id"]}
               id="provider_client_id"
             />
-            <.input
+            <.form_field
               name="provider[client_secret]"
               type="password"
               label={
@@ -728,14 +728,14 @@ defmodule FountainWeb.ConnectionsLive.Index do
                 <option value="false" selected={@provider_form["pkce"] == "false"}>Off</option>
               </select>
             </div>
-            <.input
+            <.form_field
               name="provider[env_key]"
               label="Env var (blank derives from the slug)"
               value={@provider_form["env_key"]}
               id="provider_env_key"
               placeholder="GITHUB_ACCESS_TOKEN"
             />
-            <.input
+            <.form_field
               name="provider[token_hosts]"
               label="Token hosts (space-separated)"
               value={@provider_form["token_hosts"]}

--- a/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/dashboard_live/index.ex
@@ -114,7 +114,7 @@ defmodule FountainWeb.DashboardLive.Index do
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Dashboard</h1>
         <a :if={@conversations_app} href={@conversations_app <> "#/new"}>
-          <.btn>Start a conversation ↗</.btn>
+          <.button>Start a conversation ↗</.button>
         </a>
       </div>
 

--- a/apps/fountain/lib/fountain_web/live/environments_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/form.ex
@@ -360,7 +360,14 @@ defmodule FountainWeb.EnvironmentsLive.Form do
         phx-submit="submit"
         class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200"
       >
-        <.input id="env_name" name="env[name]" label="Name" value={@form["name"]} autofocus required />
+        <.form_field
+          id="env_name"
+          name="env[name]"
+          label="Name"
+          value={@form["name"]}
+          autofocus
+          required
+        />
         <.error_msg field="name" errors={@errors} />
 
         <%!-- Packages --%>
@@ -409,7 +416,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
           <.error_msg field="packages" errors={@errors} />
         </div>
 
-        <.input
+        <.form_field
           id="setup_script"
           name="env[setup_script]"
           type="textarea"
@@ -494,14 +501,14 @@ defmodule FountainWeb.EnvironmentsLive.Form do
                 Remove
               </button>
             </div>
-            <.input
+            <.form_field
               id={"repo_#{i}_url"}
               name={"env[repositories][#{i}][url]"}
               label="URL"
               value={repo["url"] || ""}
               placeholder="https://github.com/owner/repo"
             />
-            <.input
+            <.form_field
               id={"repo_#{i}_mount_path"}
               name={"env[repositories][#{i}][mount_path]"}
               label="Mount path"
@@ -509,14 +516,14 @@ defmodule FountainWeb.EnvironmentsLive.Form do
               placeholder="/workspace/repo"
             />
             <div class="grid grid-cols-2 gap-2">
-              <.input
+              <.form_field
                 id={"repo_#{i}_secret_key"}
                 name={"env[repositories][#{i}][secret_key]"}
                 label="Secret key (optional)"
                 value={repo["secret_key"] || ""}
                 placeholder="GITHUB_TOKEN"
               />
-              <.input
+              <.form_field
                 id={"repo_#{i}_ref"}
                 name={"env[repositories][#{i}][ref]"}
                 label="Ref / branch (optional)"
@@ -563,7 +570,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
               </option>
             </select>
           </div>
-          <.input
+          <.form_field
             id="networking_config_json"
             name="env[networking_config_json]"
             type="textarea"
@@ -576,9 +583,9 @@ defmodule FountainWeb.EnvironmentsLive.Form do
         <.error_msg field="networking_config_json" errors={@errors} />
 
         <div class="flex gap-2">
-          <.btn type="submit" phx-disable-with="Saving…">Save</.btn>
+          <.button type="submit" phx-disable-with="Saving…">Save</.button>
           <.link navigate={~p"/environments"}>
-            <.btn_secondary>Cancel</.btn_secondary>
+            <.button variant="secondary">Cancel</.button>
           </.link>
         </div>
       </form>
@@ -603,9 +610,14 @@ defmodule FountainWeb.EnvironmentsLive.Form do
                 &bull;&bull;&bull;&bull;&bull;&bull;&bull;
               </td>
               <td class="py-2 text-right">
-                <.btn_danger phx-click="delete_secret" phx-value-id={s.id} data-confirm="Delete?">
+                <.button
+                  variant="danger"
+                  phx-click="delete_secret"
+                  phx-value-id={s.id}
+                  data-confirm="Delete?"
+                >
                   Delete
-                </.btn_danger>
+                </.button>
               </td>
             </tr>
           </tbody>
@@ -633,7 +645,7 @@ defmodule FountainWeb.EnvironmentsLive.Form do
             placeholder="value"
             class="flex-[2] rounded border border-zinc-300 px-3 py-2 text-sm font-mono"
           />
-          <.btn type="submit">Add secret</.btn>
+          <.button type="submit">Add secret</.button>
         </form>
       </section>
     </div>

--- a/apps/fountain/lib/fountain_web/live/environments_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/environments_live/index.ex
@@ -79,7 +79,7 @@ defmodule FountainWeb.EnvironmentsLive.Index do
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Environments</h1>
         <.link navigate={~p"/environments/new"}>
-          <.btn>+ New environment</.btn>
+          <.button>+ New environment</.button>
         </.link>
       </div>
 
@@ -202,7 +202,7 @@ defmodule FountainWeb.EnvironmentsLive.Index do
             <td class="px-4 py-3 text-right">
               <div class="inline-flex gap-1">
                 <.link navigate={~p"/environments/#{e.id}/edit"}>
-                  <.btn_secondary>Edit</.btn_secondary>
+                  <.button variant="secondary">Edit</.button>
                 </.link>
                 <button
                   class="px-2 py-1 rounded text-xs cursor-pointer bg-[var(--color-error-bg)] border border-[var(--color-error)] text-[var(--color-error-text)] hover:bg-[var(--color-error)] hover:text-white transition-colors"

--- a/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/secret_bindings_live/index.ex
@@ -350,16 +350,22 @@ defmodule FountainWeb.SecretBindingsLive.Index do
                   <span :if={!b.enabled} class="text-zinc-500">disabled</span>
                 </td>
                 <td class="px-3 py-2 text-right whitespace-nowrap space-x-2">
-                  <.btn_secondary
+                  <.button
                     :if={b.enabled or @may_bind?}
+                    variant="secondary"
                     phx-click="toggle"
                     phx-value-id={b.id}
                   >
                     {if b.enabled, do: "Disable", else: "Enable"}
-                  </.btn_secondary>
-                  <.btn_danger phx-click="delete" phx-value-id={b.id} data-confirm="Unbind?">
+                  </.button>
+                  <.button
+                    variant="danger"
+                    phx-click="delete"
+                    phx-value-id={b.id}
+                    data-confirm="Unbind?"
+                  >
                     Unbind
-                  </.btn_danger>
+                  </.button>
                 </td>
               </tr>
             </tbody>
@@ -528,7 +534,7 @@ defmodule FountainWeb.SecretBindingsLive.Index do
           </div>
 
           <div class="flex items-center gap-3">
-            <.btn type="submit">Bind</.btn>
+            <.button type="submit">Bind</.button>
             <span class="text-xs text-[var(--color-text-secondary)]">
               The secret's name is enough; its value stays where it is stored.
             </span>

--- a/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/form.ex
@@ -222,7 +222,7 @@ defmodule FountainWeb.VaultsLive.Form do
         phx-submit="submit"
         class="space-y-4 bg-white rounded shadow p-6 border border-zinc-200"
       >
-        <.input
+        <.form_field
           id="vault_name"
           name="vault[name]"
           label="Name"
@@ -232,7 +232,7 @@ defmodule FountainWeb.VaultsLive.Form do
         />
         <.error_msg field="name" errors={@errors} />
 
-        <.input
+        <.form_field
           id="vault_description"
           name="vault[description]"
           type="textarea"
@@ -243,9 +243,9 @@ defmodule FountainWeb.VaultsLive.Form do
         />
 
         <div class="flex gap-2">
-          <.btn type="submit" phx-disable-with="Saving…">Save</.btn>
+          <.button type="submit" phx-disable-with="Saving…">Save</.button>
           <.link navigate={~p"/vaults"}>
-            <.btn_secondary>Cancel</.btn_secondary>
+            <.button variant="secondary">Cancel</.button>
           </.link>
         </div>
       </form>
@@ -291,13 +291,18 @@ defmodule FountainWeb.VaultsLive.Form do
                     value={if s.expires_at, do: DateTime.to_date(s.expires_at)}
                     class="rounded border border-zinc-300 px-2 py-1 text-sm"
                   />
-                  <.btn type="submit">Save expiry</.btn>
+                  <.button type="submit">Save expiry</.button>
                 </form>
               </td>
               <td class="py-2 text-right">
-                <.btn_danger phx-click="delete_secret" phx-value-id={s.id} data-confirm="Delete?">
+                <.button
+                  variant="danger"
+                  phx-click="delete_secret"
+                  phx-value-id={s.id}
+                  data-confirm="Delete?"
+                >
                   Delete
-                </.btn_danger>
+                </.button>
               </td>
             </tr>
           </tbody>
@@ -336,7 +341,7 @@ defmodule FountainWeb.VaultsLive.Form do
             title="Expiry date (optional) — you get an email before it arrives"
             class="rounded border border-zinc-300 px-3 py-2 text-sm"
           />
-          <.btn type="submit">Add secret</.btn>
+          <.button type="submit">Add secret</.button>
         </form>
       </section>
     </div>

--- a/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
+++ b/apps/fountain/lib/fountain_web/live/vaults_live/index.ex
@@ -79,7 +79,7 @@ defmodule FountainWeb.VaultsLive.Index do
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-semibold">Vaults</h1>
         <.link navigate={~p"/vaults/new"}>
-          <.btn>+ New vault</.btn>
+          <.button>+ New vault</.button>
         </.link>
       </div>
 
@@ -171,7 +171,7 @@ defmodule FountainWeb.VaultsLive.Index do
             <td class="px-4 py-3 text-right">
               <div class="inline-flex gap-1">
                 <.link navigate={~p"/vaults/#{v.id}/edit"}>
-                  <.btn_secondary>Edit</.btn_secondary>
+                  <.button variant="secondary">Edit</.button>
                 </.link>
                 <button
                   class="px-2 py-1 rounded text-xs cursor-pointer bg-[var(--color-error-bg)] border border-[var(--color-error)] text-[var(--color-error-text)] hover:bg-[var(--color-error)] hover:text-white transition-colors"


### PR DESCRIPTION
The console still calls `btn`, `btn_secondary`, `btn_danger`, and `input`, keeping duplicate component implementations alive. Migrate all 57 calls across 10 LiveViews to `button` (with secondary/danger variants) and `form_field`, then remove those helpers and the unused `status_badge` alias.

Allow the native `list` attribute through `form_field` so the agent model picker keeps its datalist suggestions. Existing field IDs, names, values, submit types, LiveView events, and confirmation prompts are retained.

Validation:
- All 85 affected LiveView tests passed, including model autocomplete, disabled fields, agent version rollback, secret forms/bindings, connections, dashboard, and console navigation.
- Full `mix precommit` passed: compilation with warnings treated as errors, unused-dependency check, formatting, strict Credo, Dialyzer, Sobelow, production release assembly, and 6,152 tests plus 6 doctests (2 skipped, 7 excluded).
- Repository search finds no remaining calls or definitions of the retired helpers.

The first full-suite attempt used the default local test database, which lacked current migrations. Validation was rerun successfully against a separate fully migrated test database.
