### PR TITLE
fix(swift): stop cancelled runs before final status fetch

### DIFF
--- a/sdk/swift/Sources/FountainKit/Run/Run.swift
+++ b/sdk/swift/Sources/FountainKit/Run/Run.swift
@@ -155,6 +155,9 @@ public final class Run: @unchecked Sendable {
     emit(.conversation(conversation, url: url))
     do {
       try await withDeadline()
+      // AsyncThrowingStream may finish normally when its task is cancelled.
+      // Do not turn that shutdown into a successful final-status request.
+      try Task.checkCancellation()
       let (ended, died) = read { ($0, failureReason) }
       // Re-read for the conversation's own status; the turn's outcome
       // is already known, so a failure here is not worth the run.

--- a/sdk/swift/Tests/FountainKitTests/ConformanceTests.swift
+++ b/sdk/swift/Tests/FountainKitTests/ConformanceTests.swift
@@ -108,6 +108,32 @@ struct ConformanceTests {
   }
 
   @Test(.timeLimit(.minutes(1)))
+  func cancellingWithoutADeadlineDoesNotFetchFinalStatus() async throws {
+    let scenario = try timeoutScenarioWithoutOutput()
+    let transport = ScriptedTransport(exchanges: scenario.http, holdQuietTail: true)
+    let client = FountainClient(config: scenario.config, transport: transport)
+    var run: Run? = try await client.run(
+      "hello", agent: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    weak var following = run
+
+    // Wait for consume() to enter the held-open stream before cancelling.
+    for try await event in try #require(run).events {
+      if case .turnStart = event { break }
+    }
+    try #require(run).cancel()
+    do {
+      _ = try await #require(run).value()
+      Issue.record("cancelling must settle the Run with cancellation")
+    } catch is CancellationError {}
+    run = nil
+
+    // cancel() settles value() immediately. The follower still owns the Run
+    // until it exits, so wait for release before checking its last request.
+    while following != nil { await Task.yield() }
+    #expect(transport.unmatched.isEmpty)
+  }
+
+  @Test(.timeLimit(.minutes(1)))
   func publicClientDeadlineDoesNotWaitForOutput() async throws {
     var scenario = try ConformanceSuite.scenario(
       named: "run-timeout-raises-and-keeps-partial-text")


### PR DESCRIPTION
Cancelling a `Run` while its event stream is suspended can end the stream normally, allowing the cancelled follower to issue a final status GET. Check task cancellation before that fetch so cancellation stops further requests.

Adds a deterministic regression that waits for follower teardown and asserts that the cancelled run sends no final status request. The regression fails before the fix; 10 conformance tests and 4 Run tests pass with warnings treated as errors.

Found while validating the #2018 stack; this existing main defect is kept in a separate change.
