### PR TITLE
refactor(cli): remove legacy manifest apply fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ upgrade, is in
 
 ### Upgrade notes
 
+- `fountain apply` now requires Fountain server v0.3.0 or later (#2098).
+  The fallback for servers without `POST /api/apply` is removed. If the
+  endpoint returns 404, the CLI fails before individual resource requests
+  and asks you to upgrade the server or check `FOUNTAIN_BASE_URL`.
+
 - `POST /api/conversations` no longer reads the legacy
   `X-AoD-Parent-Conversation-Id` header. Use
   `X-Fountain-Parent-Conversation-Id` to record agent provenance and the parent

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/managoat/fountain/cli/api"
 	"github.com/managoat/fountain/cli/internal/manifest"
-	"github.com/managoat/fountain/cli/internal/output"
 	"github.com/managoat/fountain/cli/internal/secrets"
 	"github.com/managoat/fountain/cli/internal/substitution"
 	"github.com/spf13/cobra"
@@ -62,11 +61,9 @@ func runApply(cmd *cobra.Command, args []string) error {
 	results, err := postApply(c, buildApplyPayload(grouped))
 	if err != nil {
 		if api.StatusCode(err) == 404 {
-			// Server predates POST /api/apply — reconcile resource-by-resource.
-			legacyApply(c, grouped)
-			return nil
+			return fmt.Errorf("apply requires Fountain server v0.3.0 or later: POST /api/apply was not found; upgrade the server or check FOUNTAIN_BASE_URL: %w", err)
 		}
-		Fatalf("apply failed: %v", err)
+		return fmt.Errorf("apply failed: %w", err)
 	}
 
 	if renderApplyResults(results) {
@@ -146,9 +143,9 @@ var applyKindLabels = map[string]string{
 	"Agent":       "agent",
 }
 
-// renderApplyResults prints one line per resource in the same format the
-// per-resource loop used (`+` create, `~` update, `=` no change, `!` error to
-// stderr) and reports whether any resource or secret failed.
+// renderApplyResults prints one line per resource (`+` create, `~` update,
+// `=` no change, `!` error to stderr) and reports whether any resource or
+// secret failed.
 func renderApplyResults(results []applyResult) (anyFailed bool) {
 	for _, r := range results {
 		label := applyKindLabels[r.Kind]
@@ -193,49 +190,6 @@ func formatResultErrors(errs map[string]any) string {
 		parts = append(parts, fmt.Sprintf("%s: %v", k, errs[k]))
 	}
 	return strings.Join(parts, "; ")
-}
-
-// legacyApply is the pre-bulk reconciliation path: one GET+write per
-// resource and one POST per secret. Kept for servers without /api/apply.
-//
-// A server that has no /api/apply also has none of the kinds beyond the first
-// three, so those are reported rather than reconciled: the run failed to do
-// what the manifest asked.
-func legacyApply(c *api.Client, grouped map[string][]*manifest.Doc) {
-	envs, vaults, agents := grouped["Environment"], grouped["Vault"], grouped["Agent"]
-	envIDByName := map[string]string{}
-	anyFailed := false
-
-	for _, kind := range applyKindOrder[3:] {
-		for _, d := range grouped[kind] {
-			anyFailed = true
-			warnf("%s  !  %s: this server is too old to apply %s documents", strings.ToLower(kind), d.Name(), kind)
-		}
-	}
-
-	for _, d := range envs {
-		if envID, ok := applyEnvironment(c, d); ok {
-			envIDByName[d.Name()] = envID
-		} else {
-			anyFailed = true
-		}
-	}
-
-	for _, d := range vaults {
-		if !applyVault(c, d) {
-			anyFailed = true
-		}
-	}
-
-	for _, d := range agents {
-		if !applyAgent(c, d, envIDByName) {
-			anyFailed = true
-		}
-	}
-
-	if anyFailed {
-		os.Exit(1)
-	}
 }
 
 // ── grouping ───────────────────────────────────────────────────────────
@@ -424,171 +378,6 @@ func sortedKeys(m map[string]any) []string {
 	}
 	sort.Strings(out)
 	return out
-}
-
-// ── reconciliation ─────────────────────────────────────────────────────
-
-func applyEnvironment(c *api.Client, d *manifest.Doc) (string, bool) {
-	name := requireName(d)
-	body, secretsMap := buildBody(d, name)
-
-	existing := fetchByName(c, "/environments", name)
-	var env map[string]any
-	if existing != nil {
-		id := output.ToString(existing["id"])
-		var resp struct {
-			Data map[string]any `json:"data"`
-		}
-		if err := c.Put("/environments/"+id, body, &resp); err != nil {
-			warnf("env  !  %s (update failed): %v", name, err)
-			return "", false
-		}
-		fmt.Printf("env  ~  %s\n", name)
-		env = resp.Data
-	} else {
-		var resp struct {
-			Data map[string]any `json:"data"`
-		}
-		if err := c.Post("/environments", body, &resp); err != nil {
-			warnf("env  !  %s (create failed): %v", name, err)
-			return "", false
-		}
-		fmt.Printf("env  +  %s\n", name)
-		env = resp.Data
-	}
-
-	envID := output.ToString(env["id"])
-	if envID == "" {
-		warnf("env  !  %s: missing id in response", name)
-		return "", false
-	}
-	upsertSecrets(c, "/environments/"+envID+"/secrets", name, secretsMap)
-	return envID, true
-}
-
-func applyVault(c *api.Client, d *manifest.Doc) bool {
-	name := requireName(d)
-	body, secretsMap := buildBody(d, name)
-
-	existing := fetchByName(c, "/vaults", name)
-	var v map[string]any
-	if existing != nil {
-		id := output.ToString(existing["id"])
-		var resp struct {
-			Data map[string]any `json:"data"`
-		}
-		if err := c.Put("/vaults/"+id, body, &resp); err != nil {
-			warnf("vault  !  %s (update failed): %v", name, err)
-			return false
-		}
-		fmt.Printf("vault  ~  %s\n", name)
-		v = resp.Data
-	} else {
-		var resp struct {
-			Data map[string]any `json:"data"`
-		}
-		if err := c.Post("/vaults", body, &resp); err != nil {
-			warnf("vault  !  %s (create failed): %v", name, err)
-			return false
-		}
-		fmt.Printf("vault  +  %s\n", name)
-		v = resp.Data
-	}
-
-	vaultID := output.ToString(v["id"])
-	if vaultID == "" {
-		warnf("vault  !  %s: missing id in response", name)
-		return false
-	}
-	upsertSecrets(c, "/vaults/"+vaultID+"/secrets", name, secretsMap)
-	return true
-}
-
-func applyAgent(c *api.Client, d *manifest.Doc, envIDByName map[string]string) bool {
-	name := requireName(d)
-	spec := cloneMap(d.Spec)
-
-	if envName, ok := spec["environment"].(string); ok && envName != "" {
-		if id, ok := envIDByName[envName]; ok {
-			delete(spec, "environment")
-			spec["environment_id"] = id
-		} else {
-			warnf("agent  ?  %s: environment '%s' not in this manifest, skipping reference", name, envName)
-			delete(spec, "environment")
-		}
-	} else {
-		delete(spec, "environment")
-	}
-
-	body := spec
-	body["name"] = name
-
-	existing := fetchByName(c, "/agents", name)
-	if existing != nil {
-		id := output.ToString(existing["id"])
-		if err := c.Put("/agents/"+id, body, nil); err != nil {
-			warnf("agent  !  %s (update failed): %v", name, err)
-			return false
-		}
-		fmt.Printf("agent  ~  %s\n", name)
-	} else {
-		if err := c.Post("/agents", body, nil); err != nil {
-			warnf("agent  !  %s (create failed): %v", name, err)
-			return false
-		}
-		fmt.Printf("agent  +  %s\n", name)
-	}
-	return true
-}
-
-// buildBody returns the request body for a resource (spec minus
-// `secrets`, with `name` set) and a separate map of secrets to upsert.
-//
-// Strips ownership fields (user_id, created_by) so a malicious or
-// careless manifest can't try to attribute resources to another tenant.
-// The server enforces this on its own, but defense-in-depth: don't
-// transmit fields the server is just going to drop.
-func buildBody(d *manifest.Doc, name string) (map[string]any, map[string]any) {
-	body := cloneMap(d.Spec)
-	secretsMap, _ := body["secrets"].(map[string]any)
-	delete(body, "secrets")
-	delete(body, "user_id")
-	delete(body, "created_by")
-	body["name"] = name
-	return body, secretsMap
-}
-
-func upsertSecrets(c *api.Client, path, resourceName string, m map[string]any) {
-	if len(m) == 0 {
-		return
-	}
-	for _, k := range sortedKeys(m) {
-		v := m[k]
-		body := map[string]string{
-			"key":   k,
-			"value": output.ToString(v),
-		}
-		if err := c.Post(path, body, nil); err != nil {
-			warnf("  secret  !  %s/%s: %v", resourceName, k, err)
-			continue
-		}
-		fmt.Printf("  secret  ~  %s/%s\n", resourceName, k)
-	}
-}
-
-func fetchByName(c *api.Client, collection, name string) map[string]any {
-	var resp struct {
-		Data []map[string]any `json:"data"`
-	}
-	if err := c.Get(collection, &resp); err != nil {
-		Fatalf("GET %s failed: %v", collection, err)
-	}
-	for _, row := range resp.Data {
-		if output.ToString(row["name"]) == name {
-			return row
-		}
-	}
-	return nil
 }
 
 func requireName(d *manifest.Doc) string {

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -1,10 +1,19 @@
 package cmd
 
 import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/managoat/fountain/cli/api"
 	"github.com/managoat/fountain/cli/internal/manifest"
+	"github.com/managoat/fountain/cli/internal/secrets"
 )
 
 func doc(kind, name string, spec map[string]any) *manifest.Doc {
@@ -166,5 +175,187 @@ func TestApplyVarsPreserveLiteralValues(t *testing.T) {
 	}
 	if got := buildApplyVars(flags); !reflect.DeepEqual(got, want) {
 		t.Fatal("apply variables changed beyond the supplied literal KEY=VALUE pairs")
+	}
+}
+
+func TestRunApplyMissingEndpointDoesNotReconcileResources(t *testing.T) {
+	requests := []string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	t.Setenv("FOUNTAIN_BASE_URL", srv.URL)
+	t.Setenv("FOUNTAIN_API_KEY", "test-token")
+
+	path := filepath.Join(t.TempDir(), "resources.yml")
+	if err := os.WriteFile(path, []byte(`apiVersion: fountain/v1
+kind: Environment
+metadata:
+  name: project
+spec:
+  secrets:
+    TOKEN: test-secret
+---
+apiVersion: fountain/v1
+kind: Vault
+metadata:
+  name: personal
+---
+apiVersion: fountain/v1
+kind: Agent
+metadata:
+  name: researcher
+spec:
+  environment: project
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	err := runApply(newApplyCmd(), []string{path})
+	if err == nil {
+		t.Fatal("missing bulk endpoint must fail")
+	}
+	for _, want := range []string{"v0.3.0 or later", "POST /api/apply", "upgrade the server", "FOUNTAIN_BASE_URL"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q must include %q", err, want)
+		}
+	}
+	if !reflect.DeepEqual(requests, []string{"POST /api/apply"}) {
+		t.Fatalf("must not fall back to individual requests, got %v", requests)
+	}
+}
+
+type applyTestResolver struct{}
+
+func (applyTestResolver) Prefix() string { return "test-secret://" }
+func (applyTestResolver) Read(ref string) (string, error) {
+	if ref != "test-secret://project/TOKEN" {
+		return "", errors.New("unexpected secret reference")
+	}
+	return "resolved-token", nil
+}
+func (applyTestResolver) FormatError(err error) string { return err.Error() }
+
+func TestRunApplyBulkRequestExpandsSecrets(t *testing.T) {
+	oldResolvers := secrets.Default
+	secrets.Default = []secrets.Resolver{applyTestResolver{}}
+	t.Cleanup(func() { secrets.Default = oldResolvers })
+
+	var received []applyResource
+	requests := []string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		var payload struct {
+			Resources []applyResource `json:"resources"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Error(err)
+		}
+		received = payload.Resources
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"results":[
+			{"kind":"Environment","name":"project","action":"created","secrets":[{"key":"TOKEN","action":"upserted"}]},
+			{"kind":"Vault","name":"personal","action":"unchanged","secrets":[{"key":"REGION","action":"upserted"}]},
+			{"kind":"Agent","name":"researcher","action":"updated"}
+		]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("FOUNTAIN_BASE_URL", srv.URL)
+	t.Setenv("FOUNTAIN_API_KEY", "test-token")
+	t.Setenv("PROJECT", "project")
+
+	path := filepath.Join(t.TempDir(), "resources.yml")
+	if err := os.WriteFile(path, []byte(`apiVersion: fountain/v1
+kind: Agent
+metadata:
+  name: researcher
+spec:
+  environment: project
+---
+apiVersion: fountain/v1
+kind: Environment
+metadata:
+  name: project
+spec:
+  secrets:
+    TOKEN: test-secret://${PROJECT}/TOKEN
+---
+apiVersion: fountain/v1
+kind: Vault
+metadata:
+  name: personal
+spec:
+  secrets:
+    REGION: ${REGION}
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newApplyCmd()
+	cmd.SetArgs([]string{"-f", path, "--var", "REGION=eu-west-1"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(requests, []string{"POST /api/apply"}) {
+		t.Fatalf("want one bulk request, got %v", requests)
+	}
+	want := []applyResource{
+		{Kind: "Environment", Name: "project", Spec: map[string]any{"secrets": map[string]any{"TOKEN": "resolved-token"}}},
+		{Kind: "Vault", Name: "personal", Spec: map[string]any{"secrets": map[string]any{"REGION": "eu-west-1"}}},
+		{Kind: "Agent", Name: "researcher", Spec: map[string]any{"environment": "project"}},
+	}
+	if !reflect.DeepEqual(received, want) {
+		t.Fatalf("bulk payload = %#v, want %#v", received, want)
+	}
+}
+
+func TestPostApplyPreservesPerItemFailures(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"results":[
+			{"kind":"Environment","name":"project","action":"created","secrets":[{"key":"TOKEN","action":"error","errors":{"value":["is invalid"]}}]},
+			{"kind":"Agent","name":"researcher","action":"error","errors":{"model":["is invalid"]}},
+			{"kind":"Vault","name":"personal","action":"unchanged"}
+		]}}`))
+	}))
+	defer srv.Close()
+	t.Setenv("FOUNTAIN_BASE_URL", srv.URL)
+	t.Setenv("FOUNTAIN_API_KEY", "test-token")
+
+	results, err := postApply(activeClient(), []applyResource{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 || len(results[0].Secrets) != 1 {
+		t.Fatalf("missing per-item results: %#v", results)
+	}
+	if formatResultErrors(results[0].Secrets[0].Errors) != "value: [is invalid]" ||
+		formatResultErrors(results[1].Errors) != "model: [is invalid]" {
+		t.Fatalf("missing per-item errors: %#v", results)
+	}
+	if !renderApplyResults(results) {
+		t.Fatal("HTTP 200 must not hide resource or secret failures")
+	}
+}
+
+func TestRunApplyPreservesOtherServerErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+	t.Setenv("FOUNTAIN_BASE_URL", srv.URL)
+	t.Setenv("FOUNTAIN_API_KEY", "test-token")
+	path := filepath.Join(t.TempDir(), "resources.yml")
+	if err := os.WriteFile(path, []byte("apiVersion: fountain/v1\nkind: Vault\nmetadata:\n  name: personal\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	err := runApply(newApplyCmd(), []string{path})
+	var httpErr *api.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.Status != http.StatusForbidden {
+		t.Fatalf("want original forbidden error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "upgrade") {
+		t.Fatalf("permission error must not ask for server upgrade: %v", err)
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -432,9 +432,10 @@ The server rejects unknown `spec` keys per resource. The CLI prints those
 errors and exits nonzero; valid resources in the same manifest still apply.
 Correct a misspelled field before you retry.
 
-Against an older server with no `/api/apply`, the CLI falls back to one call
-for each resource. That older server has no `Teammate`, `Schedule` or
-`Webhook` document, so the CLI reports those and exits nonzero.
+`fountain apply` requires Fountain server v0.3.0 or later, which introduced
+`POST /api/apply`. Newer document kinds and fields can require a newer server.
+If the endpoint returns 404, the CLI exits nonzero without individual resource
+requests. Upgrade the server or check `FOUNTAIN_BASE_URL` before you retry.
 
 ### Secret references
 


### PR DESCRIPTION
`fountain apply` used to turn a missing bulk endpoint into separate environment, vault, agent and secret requests. It now requires server v0.3.0 or later and reports an actionable error on 404 without attempting those requests. The version floor is the first server tag containing bulk apply commit `bbc01073`, also recorded in the v0.3.0 changelog.

Removes the fallback and its six exclusive helpers. Bulk ordering, server-side reference resolution, ownership-field stripping, secret substitution/resolution and per-item error reporting stay in place. The CLI manual and upgrade notes explain the compatibility change.

Validation:
- Passed `cd cli && go test -count=1 ./... && go vet ./...`, including HTTP regressions for 404/no fallback, a successful bulk apply with resolved environment/vault secrets, per-item failures and unchanged 403 handling.
- Passed `cd cli && go test -race ./internal/cmd`.
- Passed `git diff --check` and `python3 scripts/conflict-markers.py`; changed Go files are gofmt clean.
- `mix precommit` cannot proceed because this isolated worktree has no Hex dependencies installed. Full server checks remain for CI/Review Loop.
- Prose advice reports existing findings outside the edited text: docs-style has three findings in other pages; Vale reports an existing sentence-length finding at `docs/cli.md:385`. Destink could not run because its `sentences` npm dependency is absent.

Closes #2098. Part of #2094.
