### PR TITLE
Remove legacy vendor transcript rendering from clients

### DIFF
--- a/apps/fountain/lib/fountain/conversations/log_event.ex
+++ b/apps/fountain/lib/fountain/conversations/log_event.ex
@@ -10,11 +10,9 @@ defmodule Fountain.Conversations.LogEvent do
 
   @kinds ~w(output stage)
   # `acp` rows hold Agent Client Protocol `session/update` notifications, one
-  # per line, exactly as `stdout` rows hold raw runtime output — what is on disk
-  # is what the agent actually said. The render path tells them apart by stream
-  # rather than by the conversation's runtime, so a conversation whose agent had
-  # the flag flipped mid-way renders its earlier turns through the legacy parser
-  # and its later ones through ACP. See decisions/0014.
+  # per line. Only ACP produces structured transcript blocks. Historical stdout
+  # and stderr remain accessible as raw event data; stored events are unchanged.
+  # See decisions/0014.
   @streams ~w(stdout stderr acp)
   @states ~w(started done failed interrupted)
 

--- a/cli/internal/cmd/acp_render_test.go
+++ b/cli/internal/cmd/acp_render_test.go
@@ -107,26 +107,31 @@ func TestGarbageOnTheACPStreamIsSkipped(t *testing.T) {
 	}
 }
 
-// The other streams must keep behaving exactly as they did — stderr in red,
-// provisioning output raw, stream-json parsed.
-func TestOtherStreamsAreUnchanged(t *testing.T) {
+// Diagnostics remain visible even though vendor transcripts are retired.
+func TestDiagnosticsAreUnchanged(t *testing.T) {
 	stderr := formatOutput(map[string]any{"kind": "output", "stream": "stderr", "data": "boom"})
-	if !strings.Contains(stderr, "boom") || !strings.Contains(stderr, "\x1b[31m") {
+	if stderr != "\x1b[31mboom\x1b[0m" {
 		t.Errorf("stderr rendering changed: %q", stderr)
 	}
 
 	setup := formatOutput(map[string]any{
 		"kind": "output", "stream": "stdout", "stage": "setup", "data": "installing",
 	})
-	if !strings.Contains(setup, "installing") {
+	if setup != "installing\n" {
 		t.Errorf("setup output rendering changed: %q", setup)
 	}
+}
 
-	legacy := formatOutput(map[string]any{
-		"kind": "output", "stream": "stdout", "stage": "turn",
-		"data": `{"type":"assistant","message":{"content":[{"type":"text","text":"legacy"}]}}`,
-	})
-	if !strings.Contains(legacy, "legacy") {
-		t.Errorf("stream-json rendering changed: %q", legacy)
+func TestHistoricalVendorOutputIsNotInterpreted(t *testing.T) {
+	for _, stage := range []string{"", "turn"} {
+		for _, raw := range []string{
+			`{"type":"assistant","message":{"content":[{"type":"text","text":"legacy"}]}}`,
+			`{"type":"result","result":"legacy result"}`,
+			`{"type":"system","subtype":"code_change_published","url":"https://example.com/pr/42"}`,
+		} {
+			if got := formatOutput(map[string]any{"stream": "stdout", "stage": stage, "data": raw}); got != "" {
+				t.Errorf("historical stdout rendered with stage %q: %q", stage, got)
+			}
+		}
 	}
 }

--- a/cli/internal/cmd/conv.go
+++ b/cli/internal/cmd/conv.go
@@ -549,37 +549,20 @@ func formatOutput(data map[string]any) string {
 		}
 		return b.String()
 	}
-	// Only turn output is runtime stream-JSON. The setup script and the
-	// provisioning stages (packages, network, clone) log raw text under
-	// their own stage — formatStreamJSONLine returns "" for anything that
-	// is not JSON, so a failing `apt install` or `git clone` produced zero
-	// visible output. Rows predating stage stamping have no stage and are
-	// turn output.
+	// Setup and provisioning stages log raw diagnostics. Historical vendor
+	// stdout has no transcript renderer; its data remains in the events API.
 	if stage, _ := data["stage"].(string); stage != "" && stage != "turn" {
 		if strings.HasSuffix(raw, "\n") {
 			return raw
 		}
 		return raw + "\n"
 	}
-	var b strings.Builder
-	for _, line := range strings.Split(raw, "\n") {
-		if line == "" {
-			continue
-		}
-		b.WriteString(formatStreamJSONLine(line))
-	}
-	return b.String()
+	return ""
 }
 
-// formatStreamJSONLine renders a single line from the assistant/user/result
-// JSON Lines stream. Mirrors conv.ex's format_stream_json_line/1.
-// formatACPLine renders one stored `session/update` for a human.
-//
-// This is not the dialect parser ADR 0015 forbids in `cli/`: ACP is the
-// protocol every supported runtime now speaks, not a vendor's format, and the
-// alternative is a CLI that shows nothing. The rendering deliberately matches
-// the stream-json path above — assistant text plain, tool calls in cyan — so
-// a gemini conversation and a claude one read the same in a terminal.
+// formatACPLine renders one stored `session/update` for a human: assistant
+// text plain, thinking dimmed, and tool calls in cyan. ACP is the protocol
+// every supported runtime speaks; vendor stdout dialects are not interpreted.
 func formatACPLine(line string) string {
 	var msg struct {
 		Method string `json:"method"`
@@ -637,96 +620,4 @@ func acpContentText(update map[string]any) string {
 	}
 	text, _ := content["text"].(string)
 	return text
-}
-
-func formatStreamJSONLine(line string) string {
-	var msg map[string]any
-	if json.Unmarshal([]byte(line), &msg) != nil {
-		return ""
-	}
-	t, _ := msg["type"].(string)
-	switch t {
-	case "system":
-		return formatSystemEvent(msg)
-
-	case "assistant":
-		message, _ := msg["message"].(map[string]any)
-		content, _ := message["content"].([]any)
-		var b strings.Builder
-		for _, item := range content {
-			c, ok := item.(map[string]any)
-			if !ok {
-				continue
-			}
-			ct, _ := c["type"].(string)
-			switch ct {
-			case "text":
-				if text, ok := c["text"].(string); ok {
-					b.WriteString(text)
-				}
-			case "tool_use":
-				name, _ := c["name"].(string)
-				input := c["input"]
-				inputJSON, _ := json.Marshal(input)
-				b.WriteString("\n\x1b[36m[")
-				b.WriteString(name)
-				b.WriteString("]\x1b[0m ")
-				b.Write(inputJSON)
-				b.WriteString("\n")
-			}
-		}
-		return b.String()
-
-	case "user":
-		message, _ := msg["message"].(map[string]any)
-		contentArr, _ := message["content"].([]any)
-		if len(contentArr) > 0 {
-			c, ok := contentArr[0].(map[string]any)
-			if ok {
-				if text, ok := c["content"].(string); ok {
-					return "\n\x1b[2m→ " + output.Truncate(text, 200) + "\x1b[0m\n"
-				}
-			}
-		}
-	case "result":
-		if r, ok := msg["result"].(string); ok {
-			return "\n\x1b[32m✓ " + r + "\x1b[0m\n"
-		}
-	}
-	return ""
-}
-
-// System notices are useful progress, not turn failures. Unknown subtypes
-// stay visible without dumping their payload into the terminal.
-func formatSystemEvent(msg map[string]any) string {
-	field := func(key string) string {
-		value, _ := msg[key].(string)
-		return strings.Join(strings.Fields(value), " ")
-	}
-	subtype := field("subtype")
-	if subtype != "code_change_published" {
-		if subtype == "" {
-			subtype = "notice"
-		}
-		return "\n\x1b[2m▸ system: " + subtype + "\x1b[0m\n"
-	}
-	label := "published"
-	if provider := field("provider"); provider != "" {
-		label += ": " + provider
-		if provider == "github" {
-			label += " pull request"
-		}
-	}
-	reference := field("repo")
-	if identifier := field("identifier"); identifier != "" {
-		reference += "#" + identifier
-	}
-	if reference != "" {
-		label += " " + reference
-	}
-	result := "\n▸ " + label + "\n"
-	if url := field("url"); url != "" {
-		result += "  " + url + "\n"
-	}
-	return result
 }

--- a/cli/internal/cmd/conv_test.go
+++ b/cli/internal/cmd/conv_test.go
@@ -159,8 +159,7 @@ func TestHandleStageEvent(t *testing.T) {
 	}
 }
 
-// Only turn output is runtime stream-JSON; setup and provisioning stages log
-// raw text. Routing everything through the JSON formatter made a failing
+// Setup and provisioning stages log raw text. Routing everything through the JSON formatter made a failing
 // `apt install` or `git clone` produce zero visible output.
 func TestFormatOutputByStage(t *testing.T) {
 	setup := map[string]any{
@@ -181,17 +180,6 @@ func TestFormatOutputByStage(t *testing.T) {
 		t.Errorf("packages-stage output was not passed through: %q", got)
 	}
 
-	// Turn output that is not valid stream-JSON still renders as before
-	// (formatStreamJSONLine owns that behaviour); the key property is that
-	// the raw-text passthrough does NOT apply to the turn stage.
-	turn := map[string]any{
-		"stream": "stdout",
-		"stage":  "turn",
-		"data":   `{"type":"unknown"}`,
-	}
-	if got := formatOutput(turn); got == `{"type":"unknown"}`+"\n" {
-		t.Errorf("turn-stage output must go through the stream-JSON formatter, got passthrough: %q", got)
-	}
 }
 
 // lastEventIDIn extracts the stream head from a `?wait=false` drain, which is
@@ -227,23 +215,5 @@ func TestTurnFailureHint(t *testing.T) {
 	}
 	if hint := turnFailureHint("acp: peer closed"); hint != "" {
 		t.Fatalf("expected no hint for an unrelated reason, got %q", hint)
-	}
-}
-
-func TestSystemNoticesInTurnOutput(t *testing.T) {
-	tests := []struct{ name, raw, want string }{
-		{"published pull request", `{"type":"system","subtype":"code_change_published","provider":"github","url":"https://github.com/acme/app/pull/42","repo":"acme/app","identifier":"42"}`, "\n▸ published: github pull request acme/app#42\n  https://github.com/acme/app/pull/42\n"},
-		{"missing optional fields", `{"type":"system","subtype":"code_change_published"}`, "\n▸ published\n"},
-		{"unknown subtype", `{"type":"system","subtype":"future_notice","secret":"do not dump"}`, "\n\x1b[2m▸ system: future_notice\x1b[0m\n"},
-		{"unknown fields stay on one line", `{"type":"system","subtype":"future\nnotice"}`, "\n\x1b[2m▸ system: future notice\x1b[0m\n"},
-		{"malformed subtype", `{"type":"system","subtype":42}`, "\n\x1b[2m▸ system: notice\x1b[0m\n"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := formatOutput(map[string]any{"stream": "stdout", "stage": "turn", "data": tt.raw})
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
-		})
 	}
 }

--- a/decisions/0014-agent-client-protocol.md
+++ b/decisions/0014-agent-client-protocol.md
@@ -993,3 +993,15 @@ available as raw log event data; this change does not delete stored events.
 
 This supersedes the retention prerequisite in the implementation notes above.
 New runtimes still integrate through ACP at the sandbox boundary.
+
+### Client transcript rendering aligned (2026-09-13)
+
+The CLI now interprets ACP output only. It no longer parses historical vendor
+stdout or its system notices. Setup and provisioning diagnostics still print
+as raw text, and stderr still prints in red. Hermes joins ACP chunks and no
+longer treats legacy stdout blocks as separate paragraphs.
+
+This follows the server's ACP-only Blocks contract. Historical rows remain
+accessible in `data` through `GET /api/conversations/:id/events`, including
+when `blocks=true` is requested. These clients require ACP conversations for
+structured transcript output; older vendor transcripts remain raw data.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,6 +171,10 @@ fountain conv delete <id>
 
 You can repeat `-i` and `--image`. Each one takes a local file path.
 
+Conversation output uses ACP. Setup and provisioning diagnostics and stderr
+remain visible. Historical vendor stdout has no formatted transcript.
+Its stored `data` remains available through `GET /api/conversations/:id/events`.
+
 ## Sandboxes
 
 A sandbox is the computer a conversation runs on. One persistent sandbox can

--- a/integrations/hermes/fountain/tools.py
+++ b/integrations/hermes/fountain/tools.py
@@ -305,7 +305,7 @@ class FountainTools:
                     st["reason"] = meta.get("reason")
             return
 
-        if kind != "output":
+        if kind != "output" or ev.get("stream") != "acp":
             return
         turn_id = ev.get("turn_id")
         if st["turn_id"] and turn_id and turn_id != st["turn_id"]:
@@ -314,17 +314,14 @@ class FountainTools:
             # Output from before our turn started (history of an older turn).
             return
         blocks = ev.get("blocks") or []
-        # ACP streams text as chunks of one message, so chunks join with
-        # nothing; a legacy stdout row is a whole message, so rows join as
-        # paragraphs. Either way, text that follows a tool call (or any other
-        # non-text block) is a new message and gets a paragraph break.
-        acp = ev.get("stream") == "acp"
+        # ACP text chunks join into one message. A tool call or other
+        # non-text block separates the next message with a paragraph break.
         for block in blocks:
             bkind = block.get("kind")
             if bkind == "text":
                 body = block.get("body") or ""
                 if body:
-                    if st["text"] and (not acp or st.get("break_before_text")) and not st["text"][-1].endswith("\n"):
+                    if st["text"] and st.get("break_before_text") and not st["text"][-1].endswith("\n"):
                         st["text"].append("\n\n")
                     st["text"].append(body)
                     st["break_before_text"] = False

--- a/integrations/hermes/tests/test_plugin.py
+++ b/integrations/hermes/tests/test_plugin.py
@@ -203,7 +203,7 @@ class RunTests(unittest.TestCase):
             self.assertEqual(out["output"], "smoke ok\n\nThe kernel is Linux.")
             self.assertEqual(out["tools_used"], ["Terminal"])
 
-    def test_legacy_stdout_text_blocks_are_paragraphs(self):
+    def test_raw_history_is_available_without_entering_the_acp_reply(self):
         with FakeFountain() as fake:
             st = fake.state
             clock = FakeClock()
@@ -214,14 +214,22 @@ class RunTests(unittest.TestCase):
                     turn = st.turns["c-1"][0]
                     st.set_status("c-1", "running")
                     st.stage("c-1", "started", 1, turn["id"])
-                    st.text("c-1", turn["id"], "first message", stream="stdout")
-                    st.text("c-1", turn["id"], "second message", stream="stdout")
+                    st.add_event("c-1", stream="stdout", turn_id=turn["id"],
+                                 data='{"type":"assistant","message":{"content":[]}}')
+                    st.add_event("c-1", stream="stderr", turn_id=turn["id"], data="diagnostic")
+                    # Even an older server's interpreted stdout blocks are ignored.
+                    st.text("c-1", turn["id"], "old parsed output", stream="stdout")
+                    st.text("c-1", turn["id"], "current ")
+                    st.text("c-1", turn["id"], "reply")
                     st.stage("c-1", "done", 1, turn["id"], exit_code=0)
                     st.set_status("c-1", "idle")
 
             clock.on_tick = on_tick
             out = json.loads(tools.run({"agent": "reviewer", "prompt": "x"}))
-            self.assertEqual(out["output"], "first message\n\nsecond message")
+            self.assertEqual(out["output"], "current reply")
+            events, _, _ = FountainClient(fake.base_url, TOKEN).events("c-1")
+            raw = [ev["data"] for ev in events if ev.get("stream") in ("stdout", "stderr")]
+            self.assertEqual(raw[:2], ['{"type":"assistant","message":{"content":[]}}', "diagnostic"])
 
     def test_timeout_returns_partial_and_wait_resumes_from_the_cursor(self):
         with FakeFountain() as fake:


### PR DESCRIPTION
The server already renders ACP transcripts only, but the CLI still parsed vendor stream-JSON and Hermes still treated old stdout blocks as paragraphs. Remove those client paths, including the CLI vendor system-notice formatter. ACP text, thinking and tool rendering, CLI setup/provisioning diagnostics and red stderr output remain intact.

Historical vendor rows remain available as raw `data` through `/api/conversations/:id/events`, also with `blocks=true`; the clients require ACP for formatted transcript output. Correct the stale LogEvent comment, document the raw-history path, and append a dated ADR update without changing historical decisions. The ADR path requires human review under the existing Review Loop policy.

Validation:
- `cd cli && go test -count=1 ./... && go vet ./...` passed, including ACP rendering, diagnostics and CLI documentation parity.
- Hermes unittest suite: 20 tests passed, including chunk joining, paragraphs after tools and raw event access without vendor interpretation.
- `okf validate decisions`, regenerated index comparison and `git diff --check` passed. OKF reports six pre-existing actor-convention warnings.
- `mix precommit` attempted; blocked because this fresh worktree has no Elixir dependencies installed. Full server verification remains for CI/Review Loop.
- The advisory docs-style scan reports three existing findings in untouched `docs/api.md`, `docs/catalog/runtimes/codex.md` and `docs/concepts/environment.md`; none in the changed CLI page.

Closes #2101.
Refs #2094.
