### PR TITLE
Remove obsolete local-peer model rejection translation

### DIFF
--- a/apps/fountain/lib/fountain/conversations/turn_machine.ex
+++ b/apps/fountain/lib/fountain/conversations/turn_machine.ex
@@ -292,12 +292,6 @@ defmodule Fountain.Conversations.TurnMachine do
     {turn, []}
   end
 
-  # Compatibility with older peers. The new peer itself stops before writing
-  # a prompt; a host-side reaction alone cannot prevent inference.
-  def handle(%__MODULE__{} = turn, {:model_rejected, requested, detail}, ctx) do
-    handle(turn, {:failed, {:model_selection_failed, requested, detail}}, ctx)
-  end
-
   def handle(%__MODULE__{} = turn, {:failed, {:model_selection_failed, requested, detail}}, _ctx) do
     message =
       "Could not select model #{requested}: #{detail}. No prompt was sent. " <>

--- a/apps/fountain/test/fountain/conversations/acp_model_contract_test.exs
+++ b/apps/fountain/test/fountain/conversations/acp_model_contract_test.exs
@@ -4,7 +4,7 @@ defmodule Fountain.Conversations.ACPModelContractTest do
 
   The library has its own suite and this does not duplicate it. What it pins
   is the half Fountain depends on and cannot see: `apps/fountain/mix.exs`
-  allows `~> 0.2.3`, so **any** 0.2.x release resolves without a change here,
+  allows `~> 0.4.2`, so later 0.4.x releases resolve without a change here,
   and this behaviour is what decides whether a turn runs at all. Since #1640 a
   `session/set_model` disagreement fails the turn before a prompt is written,
   so the blast radius of getting it wrong is every turn on the affected

--- a/apps/fountain/test/fountain/conversations/turn_machine_test.exs
+++ b/apps/fountain/test/fountain/conversations/turn_machine_test.exs
@@ -159,20 +159,25 @@ defmodule Fountain.Conversations.TurnMachineTest do
   end
 
   describe "handle/3 with a refused model" do
-    test "model_rejected fails the turn and persists selection evidence", %{
+    test "model selection failure persists evidence without an inference stamp", %{
       machine: m,
       conv: conv
     } do
       assert {updated, [{:finish, "failed", _, _}, {:drop_connection, "failed"}]} =
-               TurnMachine.handle(m, {:model_rejected, "gpt-9", "no such model"})
+               TurnMachine.handle(
+                 m,
+                 {:failed, {:model_selection_failed, "gpt-9", "no such model"}}
+               )
 
       assert updated.row.model_selection[:requested_model] == "gpt-9"
 
       assert [{"failed", %{"requested_model" => "gpt-9", "effective_model" => nil}}] =
                stages(conv.id, "model")
 
-      assert Fountain.Repo.get!(Conversations.Turn, m.row.id).model_selection["status"] ==
-               "failed"
+      saved = Fountain.Repo.get!(Conversations.Turn, m.row.id)
+      assert saved.model_selection["status"] == "failed"
+      assert saved.acp_prompt_id == nil
+      refute Map.has_key?(saved.usage || %{}, "inference")
     end
 
     test "selected model evidence comes from the peer", %{machine: m, conv: conv} do

--- a/docs/guides/operate/upgrade.md
+++ b/docs/guides/operate/upgrade.md
@@ -111,24 +111,6 @@ Sandbox adapters send ACP protocol messages, not these internal peer events.
 The cross-node termination and sandbox-loss compatibility handlers remain
 in place. Their removal is still tracked in
 [issue #2099](https://github.com/managoat/fountain/issues/2099).
-A future removal requires this upgrade order.
-
-1. Upgrade every cluster node to a bridge build containing both changes below.
-2. Wait for the rollout to finish and for all old nodes and conversation owners
-   to exit. Check every connected node, including workers outside the web deployment.
-3. Record the running image revisions and completed rollout before removing
-   the handlers. Do not infer this state from the source branch alone.
-4. Deploy the removal build only after that evidence establishes the floor.
-   Do not mix that build with nodes older than the bridge.
-
-| Bridge requirement | First commit on main | Supported message |
-|---|---|---|
-| Termination attribution | `aecaf345` (#1981) | `{:terminate_conv, opts}` with actor and request IP |
-| Sandbox-loss identity | `da27fb2c` (#2007) | `{:machine_gone, sandbox_id, event, reason, message}` |
-
-Use a bridge build that contains both commits. No completed production rollout
-or actor drain has been verified for this cleanup. The existing fallback and
-receivers therefore remain until that operational gate is satisfied.
 
 ## Match the CLI to the server
 

--- a/docs/guides/operate/upgrade.md
+++ b/docs/guides/operate/upgrade.md
@@ -96,6 +96,40 @@ Did you move migrations into a Job with `MIGRATE_ON_BOOT=false`? Then the Job
 is the upgrade step. Read
 [Run migrations in a Job](database.md#run-migrations-in-a-job).
 
+## Conversation message compatibility
+
+The server uses the `managoat_acp` peer from its own release. The audited peer
+floor is version `0.4.2`, pinned in `mix.lock`. It reports model refusal as
+`{:failed, {:model_selection_failed, requested, detail}}` before it sends a prompt.
+The retired `model_rejected` event has no receiver.
+
+Each conversation starts its peer locally. The peer monitors its owner and
+stops when that owner exits. Replace the server process during upgrades;
+hot code replacement across peer versions is not a supported upgrade path.
+Sandbox adapters send ACP protocol messages, not these internal peer events.
+
+The cross-node termination and sandbox-loss compatibility handlers remain
+in place. Their removal is still tracked in
+[issue #2099](https://github.com/managoat/fountain/issues/2099).
+A future removal requires this upgrade order.
+
+1. Upgrade every cluster node to a bridge build containing both changes below.
+2. Wait for the rollout to finish and for all old nodes and conversation owners
+   to exit. Check every connected node, including workers outside the web deployment.
+3. Record the running image revisions and completed rollout before removing
+   the handlers. Do not infer this state from the source branch alone.
+4. Deploy the removal build only after that evidence establishes the floor.
+   Do not mix that build with nodes older than the bridge.
+
+| Bridge requirement | First commit on main | Supported message |
+|---|---|---|
+| Termination attribution | `aecaf345` (#1981) | `{:terminate_conv, opts}` with actor and request IP |
+| Sandbox-loss identity | `da27fb2c` (#2007) | `{:machine_gone, sandbox_id, event, reason, message}` |
+
+Use a bridge build that contains both commits. No completed production rollout
+or actor drain has been verified for this cleanup. The existing fallback and
+receivers therefore remain until that operational gate is satisfied.
+
 ## Match the CLI to the server
 
 The CLI and the server come from the same tag. The two versions that match are


### PR DESCRIPTION
The installed `managoat_acp` 0.4.2 peer reports model refusal as `{:failed, {:model_selection_failed, requested, detail}}` before writing a prompt. Remove TurnMachine's unused `model_rejected` translation and move its regression to that canonical event. Update the contract test's stale dependency-range comment.

The peer is started locally with the conversation as owner and exits when that owner dies. Its event format comes from the server's pinned library, independent of sandbox adapter versions. Existing real-peer and server integration tests verify model refusal prevents `session/prompt`, fails the turn, publishes selection evidence, drops the connection and avoids an inference stamp.

This is a partial cleanup. Cross-node termination and sandbox-loss compatibility handlers remain: source inspection cannot establish that production actors have drained. The upgrade guide records the pinned-peer floor and server-process replacement requirement, and links the remaining work. No deployment was changed.

Before a later cross-node removal:
1. Upgrade every cluster node to a bridge build containing both `aecaf345` (#1981, attributed `{:terminate_conv, opts}`) and `da27fb2c` (#2007, sandbox-qualified `{:machine_gone, sandbox_id, event, reason, message}`).
2. Wait for all older nodes and conversation owners to exit, including workers outside the web deployment.
3. Record image revisions for every connected node and completed rollout evidence. Source revisions alone do not prove this happened.
4. Deploy the removal build only after that floor is established; do not mix it with older nodes.

No production rollout or actor drain has been verified for this cleanup, so those compatibility handlers remain.

Validation:
- Exact `mix deps.get` completed with no lockfile changes.
- Created and migrated isolated `fountain_legacy_2099_test`; targeted suites passed: **234 tests, 0 failures** (TurnMachine, real-peer ACP model contract, ConversationServer ACP, platform inference and docs guardrails).
- `git diff --check` passed. The advisory docs-style scan reports only three pre-existing findings in untouched files.
- Full `mix precommit` passed against the isolated migrated database: compile, unused dependencies, format, Credo, Dialyzer, Sobelow, prod release assembly and umbrella tests. Core: 6 doctests + 5965 tests, 0 failures (2 skipped, 7 excluded); Buzz: 144 tests, 0 failures; Support: 33 tests, 0 failures.
- Final upgrade-guide revision: docs guardrails rerun passed, 29 tests, 0 failures.

Refs #2099 and #2094. The cross-node removal and deployment verification requirements remain open.
