### PR TITLE
fix(auth): require explicit ChatGPT mode in imported files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ upgrade, is in
 
 ### Upgrade notes
 
+- ChatGPT `auth.json` imports now require explicit `"auth_mode": "chatgpt"`
+  (#2106). Use Codex 0.93.0 or newer to sign in again with file storage,
+  then paste the fresh file. Files with missing or null mode are rejected.
+  Existing stored grants continue to refresh without another import.
+
 - `fountain apply` now requires Fountain server v0.3.0 or later (#2098).
   The fallback for servers without `POST /api/apply` is removed. If the
   endpoint returns 404, the CLI fails before individual resource requests

--- a/apps/fountain/lib/fountain/platform_chatgpt/tokens.ex
+++ b/apps/fountain/lib/fountain/platform_chatgpt/tokens.ex
@@ -102,7 +102,9 @@ defmodule Fountain.PlatformChatGPT.Tokens do
 
   @doc """
   The tokens out of an `auth.json` that `codex login` wrote on a laptop.
-  Only `auth_mode: "chatgpt"` with a non-empty refresh token is accepted:
+  Codex 0.93.0 is the supported producer floor: its login writer sets
+  `auth_mode` explicitly. Only `auth_mode: "chatgpt"` with a non-empty
+  refresh token is accepted:
   an `apiKey` file is a key, not a grant, and `chatgptAuthTokens` is what
   Fountain writes, not what it takes in.
   """
@@ -134,8 +136,6 @@ defmodule Fountain.PlatformChatGPT.Tokens do
     end
   end
 
-  # `auth_mode` is absent from older files, which were all ChatGPT logins.
-  defp chatgpt_mode(%{"auth_mode" => mode}) when mode in ["chatgpt", nil], do: :ok
-  defp chatgpt_mode(%{"auth_mode" => _other}), do: {:error, :not_a_chatgpt_login}
-  defp chatgpt_mode(_file), do: :ok
+  defp chatgpt_mode(%{"auth_mode" => "chatgpt"}), do: :ok
+  defp chatgpt_mode(_file), do: {:error, :not_a_chatgpt_login}
 end

--- a/apps/fountain/lib/fountain_web/live/admin_live/inference.ex
+++ b/apps/fountain/lib/fountain_web/live/admin_live/inference.ex
@@ -183,7 +183,9 @@ defmodule FountainWeb.AdminLive.Inference do
   defp chatgpt_error(:invalid_auth_json), do: "That is not an auth.json codex wrote"
 
   defp chatgpt_error(:not_a_chatgpt_login),
-    do: "That auth.json is an API-key login, not a ChatGPT sign-in"
+    do:
+      "That auth.json must explicitly set auth_mode to chatgpt. " <>
+        "Sign in again with Codex 0.93.0 or newer using file storage, then paste the new auth.json."
 
   defp chatgpt_error(:no_refresh_token), do: "That sign-in carries no refresh token"
   defp chatgpt_error(:invalid_id_token), do: "That sign-in carries no account id"
@@ -338,8 +340,11 @@ defmodule FountainWeb.AdminLive.Inference do
 
           <form phx-submit="chatgpt_paste" class="flex flex-wrap items-end gap-2">
             <label class="block text-xs text-zinc-500">
-              Paste auth.json from <code class="font-mono">CODEX_HOME=$(mktemp -d) codex login</code>
-              <textarea
+              Paste auth.json from a fresh Codex 0.93.0 or newer ChatGPT sign-in.
+              Use file storage as described in <a
+                href="/docs/configuration#the-chatgpt-account-for-the-codex-runtime"
+                class="link"
+              >the configuration guide</a>. <textarea
                 name="auth_json"
                 rows="3"
                 autocomplete="off"

--- a/apps/fountain/test/fountain/chatgpt_auth_import_test.exs
+++ b/apps/fountain/test/fountain/chatgpt_auth_import_test.exs
@@ -1,0 +1,28 @@
+defmodule Fountain.ChatGPTAuthImportTest do
+  use Fountain.DataCase, async: false
+
+  import Fountain.ChatGPTFixtures
+
+  alias Fountain.ChatGPTAccounts
+  alias Fountain.PlatformChatGPT.Account
+  alias Fountain.Repo
+
+  test "rejected auth.json cannot replace a stored platform grant" do
+    connect!()
+    [stored] = Repo.all(Account)
+    file = Jason.decode!(auth_json(%{refresh_token: "replacement-secret"}))
+
+    for rejected <-
+          [Map.delete(file, "auth_mode")] ++
+            Enum.map([nil, "apikey", "apiKey", "chatgptAuthTokens", "unsupported"], fn mode ->
+              Map.put(file, "auth_mode", mode)
+            end) do
+      assert {:error, :not_a_chatgpt_login} =
+               ChatGPTAccounts.platform_connect_from_auth_json(Jason.encode!(rejected))
+
+      assert Repo.all(Account) == [stored]
+    end
+
+    assert {:ok, _access} = ChatGPTAccounts.platform_access_token()
+  end
+end

--- a/apps/fountain/test/fountain/platform_chatgpt/tokens_test.exs
+++ b/apps/fountain/test/fountain/platform_chatgpt/tokens_test.exs
@@ -54,10 +54,6 @@ defmodule Fountain.PlatformChatGPT.TokensTest do
 
     assert is_binary(id)
 
-    # Older files carry no auth_mode; they were all ChatGPT logins.
-    legacy = auth_json() |> Jason.decode!() |> Map.delete("auth_mode") |> Jason.encode!()
-    assert {:ok, _} = Tokens.parse_auth_json(legacy)
-
     assert {:error, :not_a_chatgpt_login} =
              Tokens.parse_auth_json(auth_json(%{auth_mode: "apiKey"}))
 
@@ -67,5 +63,32 @@ defmodule Fountain.PlatformChatGPT.TokensTest do
     assert {:error, :no_refresh_token} = Tokens.parse_auth_json(auth_json(%{refresh_token: ""}))
     assert {:error, :invalid_auth_json} = Tokens.parse_auth_json(~s({"tokens": "nope"}))
     assert {:error, :invalid_auth_json} = Tokens.parse_auth_json(42)
+  end
+
+  test "parse_auth_json/1 requires explicit ChatGPT mode without disclosing file contents" do
+    file = Jason.decode!(auth_json())
+
+    for rejected <-
+          [Map.delete(file, "auth_mode")] ++
+            Enum.map(
+              [nil, "", "apikey", "apiKey", "chatgptAuthTokens", "secret-mode", 1, %{}],
+              fn mode ->
+                Map.put(file, "auth_mode", mode)
+              end
+            ) do
+      assert {:error, :not_a_chatgpt_login} =
+               Tokens.parse_auth_json(Jason.encode!(rejected))
+    end
+
+    for malformed <- [
+          "not json",
+          "[]",
+          "null",
+          "{}",
+          ~s({"auth_mode":"chatgpt","tokens":null}),
+          ~s({"auth_mode":"apikey","OPENAI_API_KEY":"secret-api-key"})
+        ] do
+      assert {:error, :invalid_auth_json} = Tokens.parse_auth_json(malformed)
+    end
   end
 end

--- a/apps/fountain/test/fountain_web/live/admin_inference_chatgpt_live_test.exs
+++ b/apps/fountain/test/fountain_web/live/admin_inference_chatgpt_live_test.exs
@@ -104,12 +104,47 @@ defmodule FountainWeb.AdminInferenceChatGPTLiveTest do
       html =
         render_submit(lv, "chatgpt_paste", %{"auth_json" => auth_json(%{auth_mode: "apiKey"})})
 
-      assert html =~ "API-key login, not a ChatGPT sign-in"
+      assert html =~ "must explicitly set auth_mode to chatgpt"
 
       html = render_submit(lv, "chatgpt_paste", %{"auth_json" => "nope"})
       assert html =~ "not an auth.json codex wrote"
       refute PlatformChatGPT.active?()
     end
+  end
+
+  test "paste rejects absent, null and unsupported modes with safe export guidance", %{
+    conn: conn,
+    admin: admin
+  } do
+    {:ok, lv, _} = open(conn, admin)
+    file = Jason.decode!(auth_json())
+
+    for rejected <- [
+          Map.delete(file, "auth_mode"),
+          Map.put(file, "auth_mode", nil),
+          Map.put(file, "auth_mode", "secret-unsupported-mode")
+        ] do
+      html = render_submit(lv, "chatgpt_paste", %{"auth_json" => Jason.encode!(rejected)})
+      assert html =~ "must explicitly set auth_mode to chatgpt"
+      assert html =~ "Codex 0.93.0 or newer using file storage"
+      assert html =~ "paste the new auth.json"
+
+      for secret <- ["secret-unsupported-mode" | Map.values(file["tokens"])] do
+        refute html =~ secret
+      end
+    end
+
+    for rejected <- [
+          ~s({"auth_mode":"chatgpt","tokens":null}),
+          ~s({"auth_mode":"apikey","OPENAI_API_KEY":"secret-api-key"})
+        ] do
+      html = render_submit(lv, "chatgpt_paste", %{"auth_json" => rejected})
+      assert html =~ "not an auth.json codex wrote"
+      refute html =~ "secret-api-key"
+    end
+
+    refute PlatformChatGPT.active?()
+    assert Repo.all(AdminEvent) == []
   end
 
   describe "workspace token" do

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,14 +238,31 @@ Connect the account at `/admin/inference`. There are three ways in.
 - **A device code.** Fountain requests a code, shows the code and a link, and
   waits for your approval on the ChatGPT page. The account must permit
   device-code login in its ChatGPT security settings.
-- **A pasted `auth.json`.** Run `CODEX_HOME=$(mktemp -d) codex login` on a
-  laptop and paste the file it writes. This is the recipe OpenAI documents
-  for CI. After the paste, the file belongs to Fountain. Do not use it
-  anywhere else, or both copies stop.
+- **A pasted `auth.json`.** Use Codex 0.93.0 or newer on a laptop.
+  The file must contain `"auth_mode": "chatgpt"` and a refresh token.
+  Missing, null and other modes are refused. Follow the export steps below.
+  After the paste, the file belongs to Fountain. Do not use it anywhere
+  else, or both copies stop.
 - **A workspace access token.** A ChatGPT Business or Enterprise workspace
   can mint a static token in its admin console. Paste the token and its
   expiry date. This is the credential OpenAI sanctions for servers, so use it
   where you have one.
+
+For a fresh file export, run these commands and complete the ChatGPT sign-in.
+
+```bash
+FOUNTAIN_CODEX_HOME=$(mktemp -d)
+CODEX_HOME="$FOUNTAIN_CODEX_HOME" codex -c 'cli_auth_credentials_store="file"' login
+```
+
+Paste `auth.json` from that temporary directory into Fountain.
+For an older file, upgrade Codex and repeat these steps. Do not add a mode
+field to an old file. Stored Fountain grants continue to refresh without
+another import.
+
+The [Codex 0.93.0 login writer](https://github.com/openai/codex/blob/rust-v0.93.0/codex-rs/login/src/server.rs#L562)
+sets the explicit mode. This is the supported producer floor; Fountain
+checks the file format because `auth.json` contains no producer version.
 
 Fountain keeps the refresh token, encrypted under `MASTER_SECRETS_KEY`, and
 renews the access token itself. A sandbox never sees either token. The


### PR DESCRIPTION
ChatGPT file imports now require `"auth_mode": "chatgpt"`. Files with missing, null or unsupported modes fail with the existing `:not_a_chatgpt_login` classification; the admin page explains how to sign in again and export a fresh file without echoing credentials. Rejected files cannot replace an existing stored grant.

The documented producer floor is Codex 0.93.0. Its [login writer](https://github.com/openai/codex/blob/rust-v0.93.0/codex-rs/login/src/server.rs#L562) explicitly writes the mode, its [auth enum](https://github.com/openai/codex/blob/rust-v0.93.0/codex-rs/app-server-protocol/src/protocol/common.rs#L26) serializes it as `chatgpt`, and its configuration supports the documented file-storage export. Current 0.153.4 writes the same mode. Fountain checks format because the file contains no producer version. The configuration guide and upgrade notes cover fresh sign-in/export, rather than editing an old file.

Import-path audit: the admin paste path delegates to `ChatGPTAccounts.platform_connect_from_auth_json/2`, which uses the shared parser. User-owned account linking/import is explicitly unbuilt; existing user grants use a separate encrypted credential/refresh path. Neither platform nor user stored-grant refresh depends on `auth_mode`.

Validation:
- 105 targeted tests passed across token parsing, import nonreplacement, admin UI, platform account behavior, user account behavior, user refresh and documentation links. Inputs cover valid ChatGPT, missing/null/unsupported modes, malformed and API-key-only files; assertions check errors do not contain credentials.
- Full `mix precommit` passed (exit 0) on Elixir 1.19.2 / OTP 28.3 against the explicitly created and migrated isolated `fountain_2106_test` database: compile, unused-lock guard, formatting, Credo, Dialyzer (zero errors/skips), Sobelow and prod release assembly. The root suite reported 6 doctests + 5,968 core tests, 144 Buzz tests and 33 Support tests, all with zero failures (2 existing skips and 7 exclusions).
- `git diff --check` and the complete #2112 facade-removal patch's `git apply --check` pass against this change, including shared admin source/tests. No dependency on #2112 merging first.
- Destink: 112 pages clean. Vale reports no errors; docs-style reports three pre-existing findings in other pages.

Closes #2106. Part of #2094.

